### PR TITLE
Support using the TenantID instead of Tenant name

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -77,4 +77,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.TAG_PREFIX}}:latest,${{ env.TAG_PREFIX}}:v${{ steps.manifest.outputs.version }},${{ env.TAG_PREFIX }}:v${{ steps.majorversion.outputs.major_version }}
+          tags: ${{ env.TAG_PREFIX}}:latest,${{ env.TAG_PREFIX }}:v${{ steps.majorversion.outputs.major_version }},${{ env.TAG_PREFIX}}:v${{ steps.manifest.outputs.version }}

--- a/config.example.yml
+++ b/config.example.yml
@@ -12,7 +12,7 @@ mode: full
 # Required (in 'full' and 'send' mode): App. registration information
 send:
   appReg:
-    tenant: contoso # The name of the tenant (what comes before .onmicrosoft.com)
+    tenant: contoso # The name of the tenant (what comes before .onmicrosoft.com) OR your tenantID (GUID)
     id: 01234567-89ab-cdef-0123-456789abcdef
     certificate:
       thumbprint: 0123456789ABCDEF0123456789ABCDEF01234567

--- a/config.schema.json
+++ b/config.schema.json
@@ -90,7 +90,7 @@
                     "properties": {
                         "tenant": {
                             "title": "Tenant name",
-                            "description": "The part that comes before .onmicrosoft.com",
+                            "description": "The part that comes before .onmicrosoft.com OR your tenantID (GUID)",
                             "type": "string"
                         },
                         "id": {

--- a/src/classes/Config.ts
+++ b/src/classes/Config.ts
@@ -124,6 +124,14 @@ export class Config
         return this.#config.mode.toLowerCase() as IConfig['mode'];
     }
 
+    static get msalAuthority()
+    {
+        if(/^[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}$/i.test(this.clientTenant || '')) // We got a GUID instead of name?
+            return `https://login.microsoftonline.com/${this.clientTenant}`;
+        else
+            return `https://login.microsoftonline.com/${this.clientTenant}.onmicrosoft.com`;
+    }
+
     static get clientTenant()
     {
         return this.#config.send?.appReg.tenant;

--- a/src/classes/Mailer.ts
+++ b/src/classes/Mailer.ts
@@ -20,7 +20,7 @@ export class Mailer
 
     static #msalClient = (Config.clientId && (Config.clientSecret || (Config.clientCertificateThumbprint && Config.clientCertificateKeyPath)))?new ConfidentialClientApplication({
         auth: {
-            authority: `https://login.microsoftonline.com/${Config.clientTenant}.onmicrosoft.com`,
+            authority: Config.msalAuthority,
             clientId: Config.clientId,
             clientSecret: Config.clientSecret,
             clientCertificate: Config.clientCertificateThumbprint && Config.clientCertificateKeyPath?{


### PR DESCRIPTION
You can now also use your tenant ID instead of the tenant name in the config