### PR TITLE
Support BCC via JSON API format

### DIFF
--- a/src/classes/Config.ts
+++ b/src/classes/Config.ts
@@ -11,6 +11,7 @@ export interface IConfig
 {
     mode: 'full'|'receive'|'send';
     send?: {
+        mode: 'eml'|'json'; // json send mode supports bcc
         appReg: {
             /** The tenant name (the part that comes before .onmicrosoft.com) */
             tenant: string,
@@ -100,7 +101,7 @@ export class Config
             else if(!isStringValue(this.clientTenant))
                 throw new InvalidConfig('Missing "appReg.tenant" property');
         }
-        
+
         if(this.sendRetryInterval !== undefined && this.sendRetryInterval < 1)
             throw new InvalidConfig('"retryInterval" may not be smaller than 1');
         else if(this.smtpRequireAuth && !this.smtpUsers?.length)
@@ -140,6 +141,11 @@ export class Config
     static get mode()
     {
         return this.#config.mode.toLowerCase() as IConfig['mode'];
+    }
+
+    static get sendMode()
+    {
+        return this.#config.send?.mode || 'eml';
     }
 
     static get msalAuthority()
@@ -405,7 +411,7 @@ export class Config
     {
         key = key.toLowerCase();
         const arg = process.argv.find(f=>f.toLowerCase().startsWith(`--${key}`));
-        
+
         const value: string|undefined = arg?.split('=')[1];
         if(value === undefined) return undefined;
 

--- a/src/classes/Logger.ts
+++ b/src/classes/Logger.ts
@@ -44,12 +44,12 @@ export function log(level: 'verbose'|'info'|'warn'|'error', msg: string, meta?: 
     }
 
     return new Promise<void>((resolve, reject)=>{
-        logger.log(level, msg, meta, (err)=>{
+        logger.log(level, msg, meta, (err: any)=>{
             if(err)
                 console.error('An error occured while logging!', err);
             else if(DEBUG && meta)
                 console.error(meta); // Output metadata when in DEBUG mode
-            
+
             resolve();
         });
     });

--- a/src/classes/types.ts
+++ b/src/classes/types.ts
@@ -1,0 +1,40 @@
+
+export type JsonMailSchema = {
+    message: {
+        subject: string;
+        body: {
+            contentType: 'HTML' | 'Text';
+            content: string;
+        };
+        from: {
+            emailAddress: {
+                address: string;
+            };
+        };
+        toRecipients?: {
+            emailAddress: {
+                address: string;
+            };
+        }[];
+        ccRecipients?: {
+            emailAddress: {
+                address: string;
+            };
+        }[];
+        bccRecipients?: {
+            emailAddress: {
+                address: string;
+            };
+        }[];
+        attachments?: {
+            "@odata.type": "#microsoft.graph.fileAttachment";
+            name: string;
+            contentBytes: string;
+            contentType: string;
+        }[];
+    }
+};
+
+export type MetaData = {
+    allRecipients: string[];
+};


### PR DESCRIPTION
Hi,

I found out that current implementation does not support BCC recipients. 

Why is that:
- All recipients come in "RCPT TO" SMTP command one by one
- EML arrives in "DATA" SMTP command but BCC recipients may not be present
- Since library does not track RCPT TO commands, BCC recipients may get lost

I prepared an implementation that stores recipients in metadata files (alongside of the eml files). EML is parsed and sent via JSON format of Graph API endpoint. Recipients from RCPT TO and from parsed EML are diffed so that the subset can be added to BCC part of email submission.
