### PR TITLE
Fix: Inject From header into messages received without it

### DIFF
--- a/src/classes/SMTPServer.ts
+++ b/src/classes/SMTPServer.ts
@@ -115,6 +115,15 @@ export class SMTPServer
         splitter.on('data', (data: any)=>{
             if(data.type === 'node')
             {
+                // Inject from header if needed
+                try {
+                    if(!data.headers.hasHeader('From') && envelope.mailFrom)
+                        data.headers.add('From', envelope.mailFrom.address);
+                } catch(error) {
+                    log('error', `Failed to inject from header`, {error});
+                }
+
+                // Inject bcc header if needed
                 try {
                     if(!data.headers.hasHeader('Bcc')) // We don't have a BCC header?
                     {

--- a/test/02send/Helpers.ts
+++ b/test/02send/Helpers.ts
@@ -24,7 +24,7 @@ export const defaultMail: Mail.Options = {
 export async function submitAndVerifyMail(submitProps: ISubmitMail)
 {
     const { props, send, received } = await submitMail(submitProps);
-    await verifyMail(props.mail!, send, received);
+    await verifyMail(props.mail!, send.messageId, received);
 
     return {props, send, received};
 }
@@ -40,9 +40,9 @@ export async function submitMail(props: ISubmitMail)
     return {props, send, received};
 }
 
-export async function verifyMail(mail: Required<ISubmitMail>['mail'], send: SMTPTransport.SentMessageInfo, received: Message)
+export async function verifyMail(mail: Required<ISubmitMail>['mail'], messageId: string, received: Message)
 {
-    expect(received.internetMessageId, 'Message-Id from queued file doesn\'t match submitted message').to.equal(send.messageId);
+    expect(received.internetMessageId, 'Message-Id from queued file doesn\'t match submitted message').to.equal(messageId);
     
     // Addresses
     if(mail.from) expect(received.from?.emailAddress?.address, 'From address not present').to.equal(mail.from);
@@ -86,7 +86,7 @@ export async function verifyMail(mail: Required<ISubmitMail>['mail'], send: SMTP
     }
 }
 
-async function waitForMessage(msgId: string)
+export async function waitForMessage(msgId: string)
 {
     for(let i=0; i<15; i++)
     {

--- a/test/classes/LowLevelSMTPClient.ts
+++ b/test/classes/LowLevelSMTPClient.ts
@@ -1,0 +1,64 @@
+import { createConnection, Socket } from 'node:net';
+import { randomUUID } from 'node:crypto';
+
+export class LowLevelSMTPClient
+{
+    constructor(public server: string, public port: number)
+    {
+
+    }
+
+    async sendMail(from: string, rcptTo: string, headers: Record<string, string>, data: string): Promise<string>
+    {
+        // Add a messageId
+        headers['Message-ID'] ??= randomUUID().toString();
+
+        const socket = await this.#connect();
+        await this.#read(socket); // Wait for hello from server
+        await this.#writeRead(socket, `HELO ${this.server}\r\n`);
+        await this.#writeRead(socket, `MAIL FROM: <${from}>\r\n`);
+        await this.#writeRead(socket, `RCPT TO: <${rcptTo}>\r\n`);
+        await this.#writeRead(socket, `DATA\r\n`);
+        for(const [key, val] of Object.entries(headers))
+            socket.write(`${key}: ${val}\r\n`);
+        await this.#writeRead(socket, `\r\n${data}\r\n.\r\n`);
+        socket.destroy();
+
+        return headers['Message-ID'];
+    }
+
+    #connect(): Promise<Socket>
+    {
+        return new Promise<Socket>((resolve, reject)=>{
+            const socket = createConnection(this.port, this.server);
+            socket.on('error', reject);
+            socket.once('connect', ()=>{
+                socket.off('connect', reject);
+                resolve(socket);
+            });
+        });
+    }
+
+    async #writeRead(socket: Socket, data: string): Promise<string>
+    {
+        socket.write(data);
+        const response = (await this.#read(socket, 2000)).toString();
+
+        if(/^[23]\d{2} /.test(response)) // We got a 200/300 response?
+            return response;
+        else // No 200/300 response, then we throw an error
+            throw new Error(response);
+    }
+
+    #read(socket: Socket, timeout: number = 5000): Promise<Buffer>
+    {
+        const dataPromise = new Promise<Buffer>((resolve, reject)=>{
+            socket.once('data', resolve);
+        });
+        const dataTimeout = new Promise<Buffer>((resolve, reject)=>setTimeout(()=>reject(`Time-out. No data after ${timeout}ms`), timeout))
+
+        return Promise.race([dataPromise, dataTimeout]);
+    }
+}
+
+export default LowLevelSMTPClient;


### PR DESCRIPTION
Messages can be submitted without a `From:` header, in this case we insert it, because Graph API requires it

Fixes #23 