### PR TITLE
 Add more (verbose) Logging, ENV for LOG_LEVEL, fix macos build, improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
 FROM node:20-alpine
 
 ARG VERSION
 LABEL version="SMTP2Graph v${VERSION}"
 
 # Add SMTP2Graph binary
-COPY dist/server.js /bin/smtp2graph.js
+COPY --from=builder /app/dist/server.js /bin/smtp2graph.js
 COPY docker/startup.sh /bin/
 COPY docker/test.sh /bin/
 
@@ -15,4 +25,4 @@ RUN chmod +x /bin/test.sh
 WORKDIR /data
 VOLUME /data
 EXPOSE 587
-ENTRYPOINT startup.sh
+ENTRYPOINT ["/bin/startup.sh"]

--- a/config.example.yml
+++ b/config.example.yml
@@ -3,6 +3,10 @@
 # (you might need to install an extension in your IDE for this)
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SMTP2Graph/SMTP2Graph/main/config.schema.json
 
+# Optional environment variable:
+# LOG_LEVEL=error|warn|info|verbose
+# Default is verbose in development builds and info in production builds
+
 # Optional: operation mode (default = full)
 # full = Run SMTP server and relay emails to the Graph API
 # receive = Only run SMTP server and place received emails in queue (do not send them)

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,23 @@ SMTP2Graph is an SMTP server that will send messages over the Microsoft 365/Exch
 - Brute force protection
 - No issues with SPF/DKIM/DMARC (it's handled by M365)
 
+## Logging
+
+SMTP2Graph writes logs to the `logs` folder:
+
+- `error.log` (errors only)
+- `combined.log` (info and above)
+- `exceptions.log` (uncaught exceptions)
+
+You can override the runtime log level with the `LOG_LEVEL` environment variable:
+
+- `error`
+- `warn`
+- `info`
+- `verbose`
+
+Default log level is `verbose` for development builds and `info` for production builds.
+
 ## Support the project
 
 If you like this project, please consider supporting its development.

--- a/src/classes/Logger.ts
+++ b/src/classes/Logger.ts
@@ -1,101 +1,65 @@
 import path from 'path';
 import winston from 'winston';
 
-export interface ILogMeta extends Record<string, any> {
-  error?: any;
+export interface ILogMeta extends Record<string, any>
+{
+    error?: any;
 }
 
 const logsDir = 'logs';
-const supportedLogLevels = ['error', 'warn', 'info', 'verbose'] as const;
-type LogLevel = (typeof supportedLogLevels)[number];
-const defaultLogLevel = DEBUG ? 'verbose' : 'info';
-
-const configuredLogLevel = process.env.LOG_LEVEL?.toLowerCase();
-const validConfiguredLogLevel =
-  configuredLogLevel &&
-  supportedLogLevels.includes(configuredLogLevel as LogLevel)
-    ? (configuredLogLevel as LogLevel)
-    : undefined;
-const logLevel = validConfiguredLogLevel ?? defaultLogLevel;
-const consoleLogLevel = validConfiguredLogLevel ?? defaultLogLevel;
 
 const consoleFormat = winston.format.combine(
-  winston.format.colorize(),
-  winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
-  winston.format.printf(
-    (info: any) => `[${info.timestamp}] [${info.level}]: ${info.message}`,
-  ),
+    winston.format.colorize(),
+    winston.format.timestamp({format: 'YYYY-MM-DD HH:mm:ss'}),
+    winston.format.printf((info: any)=>`[${info.timestamp}] [${info.level}]: ${info.message}`),
 );
 
 const logger = winston.createLogger({
-  level: logLevel,
-  format: winston.format.combine(
-    winston.format.timestamp({ format: 'isoDateTime' }),
-    winston.format.json(),
-  ),
-  transports: [
-    new winston.transports.File({
-      filename: path.join(logsDir, 'error.log'),
-      level: 'error',
-      maxsize: 2 * 1024 * 1024,
-      maxFiles: 10,
-    }),
-    new winston.transports.File({
-      filename: path.join(logsDir, 'combined.log'),
-      level: 'info',
-      maxsize: 2 * 1024 * 1024,
-      maxFiles: 10,
-    }),
-    new winston.transports.Console({
-      level: consoleLogLevel,
-      format: consoleFormat,
-      stderrLevels: ['error'],
-    }),
-  ],
-  exceptionHandlers: [
-    new winston.transports.File({
-      filename: path.join(logsDir, 'exceptions.log'),
-      maxsize: 2 * 1024 * 1024,
-      maxFiles: 10,
-    }),
-    new winston.transports.Console({ format: consoleFormat }),
-  ],
+    level: DEBUG?'verbose':'info',
+    format: winston.format.combine(
+        winston.format.timestamp({format: 'isoDateTime'}),
+        winston.format.json(),
+    ),
+    transports: [
+        new winston.transports.File({filename: path.join(logsDir, 'error.log'), level: 'error', maxsize: 2*1024*1024, maxFiles: 10}),
+        new winston.transports.File({filename: path.join(logsDir, 'combined.log'), level: 'info', maxsize: 2*1024*1024, maxFiles: 10}),
+        new winston.transports.Console({format: consoleFormat, stderrLevels: ['error']}),
+    ],
+    exceptionHandlers: [
+        new winston.transports.File({filename: path.join(logsDir, 'exceptions.log'), maxsize: 2*1024*1024, maxFiles: 10}),
+        new winston.transports.Console({format: consoleFormat}),
+    ],
 });
 
-export function log(
-  level: 'verbose' | 'info' | 'warn',
-  msg: string,
-  meta?: ILogMeta,
-): Promise<void>;
-export function log(
-  level: 'error',
-  msg: string,
-  meta: Required<ILogMeta>,
-): Promise<void>;
-export function log(
-  level: 'verbose' | 'info' | 'warn' | 'error',
-  msg: string,
-  meta?: ILogMeta,
-): Promise<void> {
-  if (meta?.error instanceof Error) {
-    meta.name = meta.error.name;
-    meta.stack = meta.error.stack;
-    meta.error = meta.error.message;
-  }
 
-  try {
-    logger.log(level, msg, meta);
-    if (DEBUG && meta) console.error(meta); // Output metadata when in DEBUG mode
-  } catch (err) {
-    console.error('An error occured while logging!', err);
-  }
+export function log(level: 'verbose'|'info'|'warn', msg: string, meta?: ILogMeta): Promise<void>;
+export function log(level: 'error', msg: string, meta: Required<ILogMeta>): Promise<void>;
+export function log(level: 'verbose'|'info'|'warn'|'error', msg: string, meta?: ILogMeta): Promise<void>
+{
+    if(meta?.error instanceof Error)
+    {
+        meta.name = meta.error.name;
+        meta.stack = meta.error.stack;
+        meta.error = meta.error.message;
+    }
 
-  return Promise.resolve();
+    return new Promise<void>((resolve, reject)=>{
+        logger.log(level, msg, meta, (err)=>{
+            if(err)
+                console.error('An error occured while logging!', err);
+            else if(DEBUG && meta)
+                console.error(meta); // Output metadata when in DEBUG mode
+            
+            resolve();
+        });
+    });
 }
 
 /** Create a `log()` function, but prefix the `msg` with `[prefix] ` */
-export function prefixedLog(prefix: string): typeof log {
-  return function (level, msg, meta) {
-    return log(level as any, `[${prefix}] ${msg}`, meta);
-  };
+export function prefixedLog(prefix: string): typeof log
+{
+    return function(level, msg, meta)
+    {
+        return log(level as any, `[${prefix}] ${msg}`, meta);
+    };
 }

--- a/src/classes/Logger.ts
+++ b/src/classes/Logger.ts
@@ -83,14 +83,14 @@ export function log(
     meta.error = meta.error.message;
   }
 
-  return new Promise<void>((resolve, reject) => {
-    logger.log(level, msg, meta, (err) => {
-      if (err) console.error('An error occured while logging!', err);
-      else if (DEBUG && meta) console.error(meta); // Output metadata when in DEBUG mode
+  try {
+    logger.log(level, msg, meta);
+    if (DEBUG && meta) console.error(meta); // Output metadata when in DEBUG mode
+  } catch (err) {
+    console.error('An error occured while logging!', err);
+  }
 
-      resolve();
-    });
-  });
+  return Promise.resolve();
 }
 
 /** Create a `log()` function, but prefix the `msg` with `[prefix] ` */

--- a/src/classes/Logger.ts
+++ b/src/classes/Logger.ts
@@ -1,65 +1,101 @@
 import path from 'path';
 import winston from 'winston';
 
-export interface ILogMeta extends Record<string, any>
-{
-    error?: any;
+export interface ILogMeta extends Record<string, any> {
+  error?: any;
 }
 
 const logsDir = 'logs';
+const supportedLogLevels = ['error', 'warn', 'info', 'verbose'] as const;
+type LogLevel = (typeof supportedLogLevels)[number];
+const defaultLogLevel = DEBUG ? 'verbose' : 'info';
+
+const configuredLogLevel = process.env.LOG_LEVEL?.toLowerCase();
+const validConfiguredLogLevel =
+  configuredLogLevel &&
+  supportedLogLevels.includes(configuredLogLevel as LogLevel)
+    ? (configuredLogLevel as LogLevel)
+    : undefined;
+const logLevel = validConfiguredLogLevel ?? defaultLogLevel;
+const consoleLogLevel = validConfiguredLogLevel ?? defaultLogLevel;
 
 const consoleFormat = winston.format.combine(
-    winston.format.colorize(),
-    winston.format.timestamp({format: 'YYYY-MM-DD HH:mm:ss'}),
-    winston.format.printf((info: any)=>`[${info.timestamp}] [${info.level}]: ${info.message}`),
+  winston.format.colorize(),
+  winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+  winston.format.printf(
+    (info: any) => `[${info.timestamp}] [${info.level}]: ${info.message}`,
+  ),
 );
 
 const logger = winston.createLogger({
-    level: DEBUG?'verbose':'info',
-    format: winston.format.combine(
-        winston.format.timestamp({format: 'isoDateTime'}),
-        winston.format.json(),
-    ),
-    transports: [
-        new winston.transports.File({filename: path.join(logsDir, 'error.log'), level: 'error', maxsize: 2*1024*1024, maxFiles: 10}),
-        new winston.transports.File({filename: path.join(logsDir, 'combined.log'), level: 'info', maxsize: 2*1024*1024, maxFiles: 10}),
-        new winston.transports.Console({format: consoleFormat, stderrLevels: ['error']}),
-    ],
-    exceptionHandlers: [
-        new winston.transports.File({filename: path.join(logsDir, 'exceptions.log'), maxsize: 2*1024*1024, maxFiles: 10}),
-        new winston.transports.Console({format: consoleFormat}),
-    ],
+  level: logLevel,
+  format: winston.format.combine(
+    winston.format.timestamp({ format: 'isoDateTime' }),
+    winston.format.json(),
+  ),
+  transports: [
+    new winston.transports.File({
+      filename: path.join(logsDir, 'error.log'),
+      level: 'error',
+      maxsize: 2 * 1024 * 1024,
+      maxFiles: 10,
+    }),
+    new winston.transports.File({
+      filename: path.join(logsDir, 'combined.log'),
+      level: 'info',
+      maxsize: 2 * 1024 * 1024,
+      maxFiles: 10,
+    }),
+    new winston.transports.Console({
+      level: consoleLogLevel,
+      format: consoleFormat,
+      stderrLevels: ['error'],
+    }),
+  ],
+  exceptionHandlers: [
+    new winston.transports.File({
+      filename: path.join(logsDir, 'exceptions.log'),
+      maxsize: 2 * 1024 * 1024,
+      maxFiles: 10,
+    }),
+    new winston.transports.Console({ format: consoleFormat }),
+  ],
 });
 
+export function log(
+  level: 'verbose' | 'info' | 'warn',
+  msg: string,
+  meta?: ILogMeta,
+): Promise<void>;
+export function log(
+  level: 'error',
+  msg: string,
+  meta: Required<ILogMeta>,
+): Promise<void>;
+export function log(
+  level: 'verbose' | 'info' | 'warn' | 'error',
+  msg: string,
+  meta?: ILogMeta,
+): Promise<void> {
+  if (meta?.error instanceof Error) {
+    meta.name = meta.error.name;
+    meta.stack = meta.error.stack;
+    meta.error = meta.error.message;
+  }
 
-export function log(level: 'verbose'|'info'|'warn', msg: string, meta?: ILogMeta): Promise<void>;
-export function log(level: 'error', msg: string, meta: Required<ILogMeta>): Promise<void>;
-export function log(level: 'verbose'|'info'|'warn'|'error', msg: string, meta?: ILogMeta): Promise<void>
-{
-    if(meta?.error instanceof Error)
-    {
-        meta.name = meta.error.name;
-        meta.stack = meta.error.stack;
-        meta.error = meta.error.message;
-    }
+  return new Promise<void>((resolve, reject) => {
+    logger.log(level, msg, meta, (err) => {
+      if (err) console.error('An error occured while logging!', err);
+      else if (DEBUG && meta) console.error(meta); // Output metadata when in DEBUG mode
 
-    return new Promise<void>((resolve, reject)=>{
-        logger.log(level, msg, meta, (err)=>{
-            if(err)
-                console.error('An error occured while logging!', err);
-            else if(DEBUG && meta)
-                console.error(meta); // Output metadata when in DEBUG mode
-            
-            resolve();
-        });
+      resolve();
     });
+  });
 }
 
 /** Create a `log()` function, but prefix the `msg` with `[prefix] ` */
-export function prefixedLog(prefix: string): typeof log
-{
-    return function(level, msg, meta)
-    {
-        return log(level as any, `[${prefix}] ${msg}`, meta);
-    };
+export function prefixedLog(prefix: string): typeof log {
+  return function (level, msg, meta) {
+    return log(level as any, `[${prefix}] ${msg}`, meta);
+  };
 }

--- a/src/classes/Mailer.ts
+++ b/src/classes/Mailer.ts
@@ -7,178 +7,228 @@ import addressparser from 'nodemailer/lib/addressparser';
 import { ConfidentialClientApplication } from '@azure/msal-node';
 import { Config } from './Config';
 import { UnrecoverableError } from './Constants';
+import { prefixedLog } from './Logger';
 import { MsalProxy } from './MsalProxy';
 
-export class MailboxAccessDenied extends UnrecoverableError { }
-export class InvalidMailContent extends UnrecoverableError { }
-export class MessageSizeExceeded extends UnrecoverableError { }
+const log = prefixedLog('Mailer');
 
-export class Mailer
-{
-    /** Prevent getting an accesstoken in parallel */
-    static #aquireTokenMutex = new Mutex();
-    /** Prevent sending more than 4 messages in parallel (see: https://learn.microsoft.com/en-us/graph/throttling-limits#outlook-service-limits) */
-    static #sendSemaphore = new Semaphore(4);
+export class MailboxAccessDenied extends UnrecoverableError {}
+export class InvalidMailContent extends UnrecoverableError {}
+export class MessageSizeExceeded extends UnrecoverableError {}
 
-    static #msalClient = (Config.clientId && (Config.clientSecret || (Config.clientCertificateThumbprint && Config.clientCertificateKeyPath)))?new ConfidentialClientApplication({
-        auth: {
+export class Mailer {
+  /** Prevent getting an accesstoken in parallel */
+  static #aquireTokenMutex = new Mutex();
+  /** Prevent sending more than 4 messages in parallel (see: https://learn.microsoft.com/en-us/graph/throttling-limits#outlook-service-limits) */
+  static #sendSemaphore = new Semaphore(4);
+
+  static #msalClient =
+    Config.clientId &&
+    (Config.clientSecret ||
+      (Config.clientCertificateThumbprint && Config.clientCertificateKeyPath))
+      ? new ConfidentialClientApplication({
+          auth: {
             authority: Config.msalAuthority,
             clientId: Config.clientId,
             clientSecret: Config.clientSecret,
-            clientCertificate: Config.clientCertificateThumbprint && Config.clientCertificateKeyPath?{
-                thumbprint: Config.clientCertificateThumbprint,
-                privateKey: Config.clientCertificateKey!,
-            }:undefined,
-        },
-        system: Config.httpProxyConfig?{networkClient: new MsalProxy()}:undefined, // We use our custom implementation, because the `proxyUrl` property doesn't want to work
-    }):undefined;
+            clientCertificate:
+              Config.clientCertificateThumbprint &&
+              Config.clientCertificateKeyPath
+                ? {
+                    thumbprint: Config.clientCertificateThumbprint,
+                    privateKey: Config.clientCertificateKey!,
+                  }
+                : undefined,
+          },
+          system: Config.httpProxyConfig
+            ? { networkClient: new MsalProxy() }
+            : undefined, // We use our custom implementation, because the `proxyUrl` property doesn't want to work
+        })
+      : undefined;
 
-    static async sendEml(filePath: string)
-    {
-        return this.#sendSemaphore.runExclusive(async ()=>{
-            // Determine the sender
-            let sender = Config.forceMailbox;
-            if(!sender) // There's no forced sender in the config, so we get it from the mail data
-            {
-                const senderObj = await this.#findSender(filePath);
-                if(!senderObj) throw new UnrecoverableError('No sender/from address defined');
-                sender = senderObj.address;
-            }
+  static async sendEml(filePath: string) {
+    return this.#sendSemaphore.runExclusive(async () => {
+      await log('verbose', `Preparing to send mail from file "${filePath}"`);
 
-            // Fetch an accesstoken if needed
-            const token = await this.#aquireToken();
+      // Determine the sender
+      let sender = Config.forceMailbox;
+      if (
+        !sender
+      ) // There's no forced sender in the config, so we get it from the mail data
+      {
+        const senderObj = await this.#findSender(filePath);
+        if (!senderObj)
+          throw new UnrecoverableError('No sender/from address defined');
+        sender = senderObj.address;
+        await log(
+          'verbose',
+          `Resolved sender "${sender}" from message headers`,
+        );
+      } else
+        await log('verbose', `Using forced sender "${sender}" from config`);
 
-            // Send the message
-            const readStream = fs.createReadStream(filePath);
-            try {
-                await this.#retryableRequest({
-                    method: 'post',
-                    url: `https://graph.microsoft.com/v1.0/users/${sender}/sendMail`,
-                    data: readStream.pipe(new Base64Encode()),
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        'Content-Type': 'text/plain',
-                        'User-Agent': `SMPT2Graph/${VERSION}`,
-                    },
-                    proxy: Config.httpProxyConfig,
-                });
-            } catch(error: any) {
-                if(isAxiosError(error) && error.response?.data)
-                {
-                    const data = error.response?.data;
-                    if('error' in data && 'code' in data.error)
-                    {
-                        if(data.error.code === 'ErrorAccessDenied')
-                            throw new MailboxAccessDenied(`Access to mailbox "${sender}" denied`);
-                        else if(data.error.code === 'ErrorMimeContentInvalidBase64String')
-                            throw new InvalidMailContent(`Invalid content for mail "${filePath}"`);
-                        else if(data.error.code === 'ErrorMessageSizeExceeded')
-                            throw new MessageSizeExceeded(`The message exceeds the maximum supported size for mail "${filePath}"`);
-                        else
-                            throw new Error(JSON.stringify(data.error));
-                    }
-                    else
-                        throw data;
-                }
-                else
-                    throw error;
-            } finally {
-                readStream.destroy();
-            }
+      // Fetch an accesstoken if needed
+      await log('verbose', `Acquiring Graph access token`);
+      const token = await this.#aquireToken();
+      await log('verbose', `Acquired Graph access token`);
+
+      // Send the message
+      const readStream = fs.createReadStream(filePath);
+      try {
+        await log(
+          'verbose',
+          `Sending message as "${sender}" via Microsoft Graph`,
+        );
+        await this.#retryableRequest({
+          method: 'post',
+          url: `https://graph.microsoft.com/v1.0/users/${sender}/sendMail`,
+          data: readStream.pipe(new Base64Encode()),
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'text/plain',
+            'User-Agent': `SMPT2Graph/${VERSION}`,
+          },
+          proxy: Config.httpProxyConfig,
         });
-    }
-
-    /** Automatically retry a request when it's being throttled by the Graph API */
-    static async #retryableRequest<RequestData = any, ReponseData = any>(request: AxiosRequestConfig<RequestData>): Promise<AxiosResponse<RequestData, ReponseData>>
-    {
-        const retryLimit = 3;
-        let retryCount = 0;
-        let wait = 200;
-
-        const retry = async (): Promise<AxiosResponse<RequestData, ReponseData>> =>
-        {
-            const abortController = new AbortController();
-            const connectTimeout = setTimeout(()=>abortController.abort(`Server did not respond within 10 seconds`), 10000);
-            const overallTimeout = setTimeout(()=>abortController.abort(`Failed to send message within 120 seconds`), 120000);
-
-            try {
-                return await axios({
-                    ...request,
-                    signal: abortController.signal,
-                    onUploadProgress: progress=>{
-                        clearTimeout(connectTimeout);
-                    },
-                });
-            } catch(error) {
-                if(++retryCount > retryLimit) // We've reached our retry limit?
-                    throw error;
-                else if(isAxiosError(error) && (error.response?.status === 429 || error.response?.status === 503 || error.response?.status === 504)) // We got a retryable response?
-                {
-                    const retryAfter = error.response.headers['Retry-After'];
-                    if(retryAfter && !isNaN(retryAfter)) // We got throttled
-                        wait = parseInt(retryAfter) * 1000;
-                    else
-                        wait *= 2;
-
-                    await this.#sleep(wait);
-
-                    return retry();
-                }
-                else if(axios.isCancel(error) && abortController.signal.aborted)
-                    throw abortController.signal.reason;
-                else // Unknown error response, throw the error
-                    throw error;
-            } finally {
-                clearTimeout(connectTimeout);
-                clearTimeout(overallTimeout);
-            }
-        };
-
-        return retry();
-    }
-
-    static #sleep(ms: number): Promise<void>
-    {
-        return new Promise(r=>setTimeout(r, ms));
-    }
-
-    /** Get sender address from EML/RFC822 data */
-    static async #findSender(filePath: string)
-    {
-        const readStream = fs.createReadStream(filePath);
-        const reader = readline.createInterface({
-            input: readStream,
-            crlfDelay: Infinity, // To treat \r\n and \n the same
+        await log('verbose', `Message sent successfully as "${sender}"`);
+      } catch (error: any) {
+        await log('error', `Failed to send message as "${sender}"`, {
+          error,
+          filePath,
+          sender,
         });
-
-        for await(const line of reader)
-        {
-            if(line === '') // We've reached the end of the headers?
-                break;
-            else if(line.toLowerCase().startsWith('sender:') || line.toLowerCase().startsWith('from:')) // Found the sender?
-            {
-                const parsed = addressparser(line.substring(line.indexOf(':')+1), {flatten: true});
-                if(parsed.length && parsed[0].address) // We got an address?
-                {
-                    readStream.destroy();
-                    return parsed[0];
-                }
-            }
-        }
-
+        if (isAxiosError(error) && error.response?.data) {
+          const data = error.response?.data;
+          if ('error' in data && 'code' in data.error) {
+            if (data.error.code === 'ErrorAccessDenied')
+              throw new MailboxAccessDenied(
+                `Access to mailbox "${sender}" denied`,
+              );
+            else if (data.error.code === 'ErrorMimeContentInvalidBase64String')
+              throw new InvalidMailContent(
+                `Invalid content for mail "${filePath}"`,
+              );
+            else if (data.error.code === 'ErrorMessageSizeExceeded')
+              throw new MessageSizeExceeded(
+                `The message exceeds the maximum supported size for mail "${filePath}"`,
+              );
+            else throw new Error(JSON.stringify(data.error));
+          } else throw data;
+        } else throw error;
+      } finally {
         readStream.destroy();
-    }
+      }
+    });
+  }
 
-    static async #aquireToken(): Promise<string>
-    {
-        return this.#aquireTokenMutex.runExclusive(async ()=>{
-            if(!this.#msalClient) throw new UnrecoverableError('Trying to login without an application registration');
+  /** Automatically retry a request when it's being throttled by the Graph API */
+  static async #retryableRequest<RequestData = any, ReponseData = any>(
+    request: AxiosRequestConfig<RequestData>,
+  ): Promise<AxiosResponse<RequestData, ReponseData>> {
+    const retryLimit = 3;
+    let retryCount = 0;
+    let wait = 200;
 
-            const res = await this.#msalClient.acquireTokenByClientCredential({
-                scopes: ['https://graph.microsoft.com/.default'],
-            });
-            return res?.accessToken!;
+    const retry = async (): Promise<
+      AxiosResponse<RequestData, ReponseData>
+    > => {
+      const abortController = new AbortController();
+      const connectTimeout = setTimeout(
+        () => abortController.abort(`Server did not respond within 10 seconds`),
+        10000,
+      );
+      const overallTimeout = setTimeout(
+        () =>
+          abortController.abort(`Failed to send message within 120 seconds`),
+        120000,
+      );
+
+      try {
+        return await axios({
+          ...request,
+          signal: abortController.signal,
+          onUploadProgress: (progress) => {
+            clearTimeout(connectTimeout);
+          },
         });
+      } catch (error) {
+        if (++retryCount > retryLimit)
+          // We've reached our retry limit?
+          throw error;
+        else if (
+          isAxiosError(error) &&
+          (error.response?.status === 429 ||
+            error.response?.status === 503 ||
+            error.response?.status === 504)
+        ) // We got a retryable response?
+        {
+          const retryAfter = error.response.headers['Retry-After'];
+          if (retryAfter && !isNaN(retryAfter))
+            // We got throttled
+            wait = parseInt(retryAfter) * 1000;
+          else wait *= 2;
+
+          await this.#sleep(wait);
+
+          return retry();
+        } else if (axios.isCancel(error) && abortController.signal.aborted)
+          throw abortController.signal.reason; // Unknown error response, throw the error
+        else throw error;
+      } finally {
+        clearTimeout(connectTimeout);
+        clearTimeout(overallTimeout);
+      }
+    };
+
+    return retry();
+  }
+
+  static #sleep(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms));
+  }
+
+  /** Get sender address from EML/RFC822 data */
+  static async #findSender(filePath: string) {
+    const readStream = fs.createReadStream(filePath);
+    const reader = readline.createInterface({
+      input: readStream,
+      crlfDelay: Infinity, // To treat \r\n and \n the same
+    });
+
+    for await (const line of reader) {
+      if (line === '')
+        // We've reached the end of the headers?
+        break;
+      else if (
+        line.toLowerCase().startsWith('sender:') ||
+        line.toLowerCase().startsWith('from:')
+      ) // Found the sender?
+      {
+        const parsed = addressparser(line.substring(line.indexOf(':') + 1), {
+          flatten: true,
+        });
+        if (parsed.length && parsed[0].address) // We got an address?
+        {
+          readStream.destroy();
+          return parsed[0];
+        }
+      }
     }
 
+    readStream.destroy();
+  }
+
+  static async #aquireToken(): Promise<string> {
+    return this.#aquireTokenMutex.runExclusive(async () => {
+      if (!this.#msalClient)
+        throw new UnrecoverableError(
+          'Trying to login without an application registration',
+        );
+
+      const res = await this.#msalClient.acquireTokenByClientCredential({
+        scopes: ['https://graph.microsoft.com/.default'],
+      });
+      return res?.accessToken!;
+    });
+  }
 }

--- a/src/classes/Mailer.ts
+++ b/src/classes/Mailer.ts
@@ -10,56 +10,44 @@ import { UnrecoverableError } from './Constants';
 import { prefixedLog } from './Logger';
 import { MsalProxy } from './MsalProxy';
 
+export class MailboxAccessDenied extends UnrecoverableError { }
+export class InvalidMailContent extends UnrecoverableError { }
+export class MessageSizeExceeded extends UnrecoverableError { }
+
 const log = prefixedLog('Mailer');
 
-export class MailboxAccessDenied extends UnrecoverableError {}
-export class InvalidMailContent extends UnrecoverableError {}
-export class MessageSizeExceeded extends UnrecoverableError {}
+export class Mailer
+{
+    /** Prevent getting an accesstoken in parallel */
+    static #aquireTokenMutex = new Mutex();
+    /** Prevent sending more than 4 messages in parallel (see: https://learn.microsoft.com/en-us/graph/throttling-limits#outlook-service-limits) */
+    static #sendSemaphore = new Semaphore(4);
 
-export class Mailer {
-  /** Prevent getting an accesstoken in parallel */
-  static #aquireTokenMutex = new Mutex();
-  /** Prevent sending more than 4 messages in parallel (see: https://learn.microsoft.com/en-us/graph/throttling-limits#outlook-service-limits) */
-  static #sendSemaphore = new Semaphore(4);
-
-  static #msalClient =
-    Config.clientId &&
-    (Config.clientSecret ||
-      (Config.clientCertificateThumbprint && Config.clientCertificateKeyPath))
-      ? new ConfidentialClientApplication({
-          auth: {
+    static #msalClient = (Config.clientId && (Config.clientSecret || (Config.clientCertificateThumbprint && Config.clientCertificateKeyPath)))?new ConfidentialClientApplication({
+        auth: {
             authority: Config.msalAuthority,
             clientId: Config.clientId,
             clientSecret: Config.clientSecret,
-            clientCertificate:
-              Config.clientCertificateThumbprint &&
-              Config.clientCertificateKeyPath
-                ? {
-                    thumbprint: Config.clientCertificateThumbprint,
-                    privateKey: Config.clientCertificateKey!,
-                  }
-                : undefined,
-          },
-          system: Config.httpProxyConfig
-            ? { networkClient: new MsalProxy() }
-            : undefined, // We use our custom implementation, because the `proxyUrl` property doesn't want to work
-        })
-      : undefined;
+            clientCertificate: Config.clientCertificateThumbprint && Config.clientCertificateKeyPath?{
+                thumbprint: Config.clientCertificateThumbprint,
+                privateKey: Config.clientCertificateKey!,
+            }:undefined,
+        },
+        system: Config.httpProxyConfig?{networkClient: new MsalProxy()}:undefined, // We use our custom implementation, because the `proxyUrl` property doesn't want to work
+    }):undefined;
 
-  static async sendEml(filePath: string) {
-    return this.#sendSemaphore.runExclusive(async () => {
+    static async sendEml(filePath: string)
+    {
+        return this.#sendSemaphore.runExclusive(async ()=>{
       await log('verbose', `Preparing to send mail from file "${filePath}"`);
 
-      // Determine the sender
-      let sender = Config.forceMailbox;
-      if (
-        !sender
-      ) // There's no forced sender in the config, so we get it from the mail data
-      {
-        const senderObj = await this.#findSender(filePath);
-        if (!senderObj)
-          throw new UnrecoverableError('No sender/from address defined');
-        sender = senderObj.address;
+            // Determine the sender
+            let sender = Config.forceMailbox;
+            if(!sender) // There's no forced sender in the config, so we get it from the mail data
+            {
+                const senderObj = await this.#findSender(filePath);
+                if(!senderObj) throw new UnrecoverableError('No sender/from address defined');
+                sender = senderObj.address;
         await log(
           'verbose',
           `Resolved sender "${sender}" from message headers`,
@@ -67,168 +55,152 @@ export class Mailer {
       } else
         await log('verbose', `Using forced sender "${sender}" from config`);
 
-      // Fetch an accesstoken if needed
+            // Fetch an accesstoken if needed
       await log('verbose', `Acquiring Graph access token`);
-      const token = await this.#aquireToken();
+            const token = await this.#aquireToken();
       await log('verbose', `Acquired Graph access token`);
 
-      // Send the message
-      const readStream = fs.createReadStream(filePath);
-      try {
+            // Send the message
+            const readStream = fs.createReadStream(filePath);
+            try {
         await log(
           'verbose',
           `Sending message as "${sender}" via Microsoft Graph`,
         );
-        await this.#retryableRequest({
-          method: 'post',
-          url: `https://graph.microsoft.com/v1.0/users/${sender}/sendMail`,
-          data: readStream.pipe(new Base64Encode()),
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'text/plain',
-            'User-Agent': `SMPT2Graph/${VERSION}`,
-          },
-          proxy: Config.httpProxyConfig,
-        });
+                await this.#retryableRequest({
+                    method: 'post',
+                    url: `https://graph.microsoft.com/v1.0/users/${sender}/sendMail`,
+                    data: readStream.pipe(new Base64Encode()),
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        'Content-Type': 'text/plain',
+                        'User-Agent': `SMPT2Graph/${VERSION}`,
+                    },
+                    proxy: Config.httpProxyConfig,
+                });
         await log('verbose', `Message sent successfully as "${sender}"`);
-      } catch (error: any) {
+            } catch(error: any) {
         await log('error', `Failed to send message as "${sender}"`, {
           error,
           filePath,
           sender,
         });
-        if (isAxiosError(error) && error.response?.data) {
-          const data = error.response?.data;
-          if ('error' in data && 'code' in data.error) {
-            if (data.error.code === 'ErrorAccessDenied')
-              throw new MailboxAccessDenied(
-                `Access to mailbox "${sender}" denied`,
-              );
-            else if (data.error.code === 'ErrorMimeContentInvalidBase64String')
-              throw new InvalidMailContent(
-                `Invalid content for mail "${filePath}"`,
-              );
-            else if (data.error.code === 'ErrorMessageSizeExceeded')
-              throw new MessageSizeExceeded(
-                `The message exceeds the maximum supported size for mail "${filePath}"`,
-              );
-            else throw new Error(JSON.stringify(data.error));
-          } else throw data;
-        } else throw error;
-      } finally {
-        readStream.destroy();
-      }
-    });
-  }
-
-  /** Automatically retry a request when it's being throttled by the Graph API */
-  static async #retryableRequest<RequestData = any, ReponseData = any>(
-    request: AxiosRequestConfig<RequestData>,
-  ): Promise<AxiosResponse<RequestData, ReponseData>> {
-    const retryLimit = 3;
-    let retryCount = 0;
-    let wait = 200;
-
-    const retry = async (): Promise<
-      AxiosResponse<RequestData, ReponseData>
-    > => {
-      const abortController = new AbortController();
-      const connectTimeout = setTimeout(
-        () => abortController.abort(`Server did not respond within 10 seconds`),
-        10000,
-      );
-      const overallTimeout = setTimeout(
-        () =>
-          abortController.abort(`Failed to send message within 120 seconds`),
-        120000,
-      );
-
-      try {
-        return await axios({
-          ...request,
-          signal: abortController.signal,
-          onUploadProgress: (progress) => {
-            clearTimeout(connectTimeout);
-          },
+                if(isAxiosError(error) && error.response?.data)
+                {
+                    const data = error.response?.data;
+                    if('error' in data && 'code' in data.error)
+                    {
+                        if(data.error.code === 'ErrorAccessDenied')
+                            throw new MailboxAccessDenied(`Access to mailbox "${sender}" denied`);
+                        else if(data.error.code === 'ErrorMimeContentInvalidBase64String')
+                            throw new InvalidMailContent(`Invalid content for mail "${filePath}"`);
+                        else if(data.error.code === 'ErrorMessageSizeExceeded')
+                            throw new MessageSizeExceeded(`The message exceeds the maximum supported size for mail "${filePath}"`);
+                        else
+                            throw new Error(JSON.stringify(data.error));
+                    }
+                    else
+                        throw data;
+                }
+                else
+                    throw error;
+            } finally {
+                readStream.destroy();
+            }
         });
-      } catch (error) {
-        if (++retryCount > retryLimit)
-          // We've reached our retry limit?
-          throw error;
-        else if (
-          isAxiosError(error) &&
-          (error.response?.status === 429 ||
-            error.response?.status === 503 ||
-            error.response?.status === 504)
-        ) // We got a retryable response?
-        {
-          const retryAfter = error.response.headers['Retry-After'];
-          if (retryAfter && !isNaN(retryAfter))
-            // We got throttled
-            wait = parseInt(retryAfter) * 1000;
-          else wait *= 2;
-
-          await this.#sleep(wait);
-
-          return retry();
-        } else if (axios.isCancel(error) && abortController.signal.aborted)
-          throw abortController.signal.reason; // Unknown error response, throw the error
-        else throw error;
-      } finally {
-        clearTimeout(connectTimeout);
-        clearTimeout(overallTimeout);
-      }
-    };
-
-    return retry();
-  }
-
-  static #sleep(ms: number): Promise<void> {
-    return new Promise((r) => setTimeout(r, ms));
-  }
-
-  /** Get sender address from EML/RFC822 data */
-  static async #findSender(filePath: string) {
-    const readStream = fs.createReadStream(filePath);
-    const reader = readline.createInterface({
-      input: readStream,
-      crlfDelay: Infinity, // To treat \r\n and \n the same
-    });
-
-    for await (const line of reader) {
-      if (line === '')
-        // We've reached the end of the headers?
-        break;
-      else if (
-        line.toLowerCase().startsWith('sender:') ||
-        line.toLowerCase().startsWith('from:')
-      ) // Found the sender?
-      {
-        const parsed = addressparser(line.substring(line.indexOf(':') + 1), {
-          flatten: true,
-        });
-        if (parsed.length && parsed[0].address) // We got an address?
-        {
-          readStream.destroy();
-          return parsed[0];
-        }
-      }
     }
 
-    readStream.destroy();
-  }
+    /** Automatically retry a request when it's being throttled by the Graph API */
+    static async #retryableRequest<RequestData = any, ReponseData = any>(request: AxiosRequestConfig<RequestData>): Promise<AxiosResponse<RequestData, ReponseData>>
+    {
+        const retryLimit = 3;
+        let retryCount = 0;
+        let wait = 200;
 
-  static async #aquireToken(): Promise<string> {
-    return this.#aquireTokenMutex.runExclusive(async () => {
-      if (!this.#msalClient)
-        throw new UnrecoverableError(
-          'Trying to login without an application registration',
-        );
+        const retry = async (): Promise<AxiosResponse<RequestData, ReponseData>> =>
+        {
+            const abortController = new AbortController();
+            const connectTimeout = setTimeout(()=>abortController.abort(`Server did not respond within 10 seconds`), 10000);
+            const overallTimeout = setTimeout(()=>abortController.abort(`Failed to send message within 120 seconds`), 120000);
 
-      const res = await this.#msalClient.acquireTokenByClientCredential({
-        scopes: ['https://graph.microsoft.com/.default'],
-      });
-      return res?.accessToken!;
-    });
-  }
+            try {
+                return await axios({
+                    ...request,
+                    signal: abortController.signal,
+                    onUploadProgress: progress=>{
+                        clearTimeout(connectTimeout);
+                    },
+                });
+            } catch(error) {
+                if(++retryCount > retryLimit) // We've reached our retry limit?
+                    throw error;
+                else if(isAxiosError(error) && (error.response?.status === 429 || error.response?.status === 503 || error.response?.status === 504)) // We got a retryable response?
+                {
+                    const retryAfter = error.response.headers['Retry-After'];
+                    if(retryAfter && !isNaN(retryAfter)) // We got throttled
+                        wait = parseInt(retryAfter) * 1000;
+                    else
+                        wait *= 2;
+
+                    await this.#sleep(wait);
+
+                    return retry();
+                }
+                else if(axios.isCancel(error) && abortController.signal.aborted)
+                    throw abortController.signal.reason;
+                else // Unknown error response, throw the error
+                    throw error;
+            } finally {
+                clearTimeout(connectTimeout);
+                clearTimeout(overallTimeout);
+            }
+        };
+
+        return retry();
+    }
+
+    static #sleep(ms: number): Promise<void>
+    {
+        return new Promise(r=>setTimeout(r, ms));
+    }
+
+    /** Get sender address from EML/RFC822 data */
+    static async #findSender(filePath: string)
+    {
+        const readStream = fs.createReadStream(filePath);
+        const reader = readline.createInterface({
+            input: readStream,
+            crlfDelay: Infinity, // To treat \r\n and \n the same
+        });
+
+        for await(const line of reader)
+        {
+            if(line === '') // We've reached the end of the headers?
+                break;
+            else if(line.toLowerCase().startsWith('sender:') || line.toLowerCase().startsWith('from:')) // Found the sender?
+            {
+                const parsed = addressparser(line.substring(line.indexOf(':')+1), {flatten: true});
+                if(parsed.length && parsed[0].address) // We got an address?
+                {
+                    readStream.destroy();
+                    return parsed[0];
+                }
+            }
+        }
+
+        readStream.destroy();
+    }
+
+    static async #aquireToken(): Promise<string>
+    {
+        return this.#aquireTokenMutex.runExclusive(async ()=>{
+            if(!this.#msalClient) throw new UnrecoverableError('Trying to login without an application registration');
+
+            const res = await this.#msalClient.acquireTokenByClientCredential({
+                scopes: ['https://graph.microsoft.com/.default'],
+            });
+            return res?.accessToken!;
+        });
+    }
+
 }

--- a/src/classes/SMTPServer.ts
+++ b/src/classes/SMTPServer.ts
@@ -12,128 +12,119 @@ import { MailQueue } from './MailQueue';
 
 const log = prefixedLog('SMTPServer');
 
-export class SMTPServer {
-  #server: NodeSMTP;
-  #queue: MailQueue;
-  #rateLimiter = new RateLimiterMemory({
-    duration: Config.smtpRateLimitDuration,
-    points: Config.smtpRateLimitLimit,
-  });
-  #authLimiter = new RateLimiterMemory({
-    duration: Config.smtpAuthLimitDuration,
-    points: Config.smtpAuthLimitLimit,
-  });
-
-  constructor(queue: MailQueue) {
-    this.#queue = queue;
-    this.#server = new NodeSMTP({
-      onConnect: this.#onConnect,
-      onAuth: this.#onAuth,
-      onMailFrom: this.#onMailFrom,
-      onData: this.#onData,
-      authOptional: !Config.smtpRequireAuth,
-      banner: Config.smtpBanner ?? `SMTP2Graph ${VERSION}`,
-      size: Config.smtpMaxSize,
-      secure: Config.smtpSecure,
-      key: Config.smtpTlsKey,
-      cert: Config.smtpTlsCert,
-      allowInsecureAuth: Config.smtpAllowTls
-        ? Config.smtpAllowInsecureAuth
-        : true,
-      disabledCommands: Config.smtpAllowTls ? undefined : ['STARTTLS'],
+export class SMTPServer
+{
+    #server: NodeSMTP;
+    #queue: MailQueue;
+    #rateLimiter = new RateLimiterMemory({
+        duration: Config.smtpRateLimitDuration,
+        points: Config.smtpRateLimitLimit,
     });
-  }
-
-  listen() {
-    return new Promise<void>((resolve, reject) => {
-      this.#server.on('error', reject);
-
-      this.#server.listen(Config.smtpPort, Config.smtpListenIp, () => {
-        log(
-          'info',
-          `Server started on ${Config.smtpListenIp || 'any-ip'}:${Config.smtpPort}`,
-        );
-        this.#server.off('error', reject);
-        this.#server.on('error', (error) => {
-          log('error', `An error occured`, { error });
-        });
-        resolve();
-      });
+    #authLimiter = new RateLimiterMemory({
+        duration: Config.smtpAuthLimitDuration,
+        points: Config.smtpAuthLimitLimit,
     });
-  }
 
-  #onConnect: SMTPServerOptions['onConnect'] = (session, callback) => {
-    if (Config.isIpAllowed(session.remoteAddress)) {
-      this.#rateLimiter
-        .consume('all')
-        .then((rateLimit) => {
-          callback();
-        })
-        .catch((rateLimit: RateLimiterRes) => {
-          callback(
-            new Error(
-              `Rate limit exceeded. Try again in ${Math.ceil(rateLimit.msBeforeNext / 1000)} seconds`,
-            ),
-          );
+    constructor(queue: MailQueue)
+    {
+        this.#queue = queue;
+        this.#server = new NodeSMTP({
+            onConnect: this.#onConnect,
+            onAuth: this.#onAuth,
+            onMailFrom: this.#onMailFrom,
+            onData: this.#onData,
+            authOptional: !Config.smtpRequireAuth,
+            banner: Config.smtpBanner ?? `SMTP2Graph ${VERSION}`,
+            size: Config.smtpMaxSize,
+            secure: Config.smtpSecure,
+            key: Config.smtpTlsKey,
+            cert: Config.smtpTlsCert,
+            allowInsecureAuth: Config.smtpAllowTls?Config.smtpAllowInsecureAuth:true,
+            disabledCommands: Config.smtpAllowTls?undefined:['STARTTLS'],
         });
-    } else
-      callback(
-        new Error(`IP ${session.remoteAddress} is not allowed to connect`),
-      );
-  };
-
-  #onAuth: SMTPServerOptions['onAuth'] = (auth, session, callback) => {
-    this.#authLimiter
-      .consume(session.remoteAddress)
-      .then((rateLimit) => {
-        if (!auth.username || !auth.password)
-          callback(new Error('Unsupported authentication method'));
-        else if (Config.isUserAllowed(auth.username, auth.password))
-          callback(null, { user: auth.username });
-        else callback(new Error('Invalid login'));
-      })
-      .catch((rateLimit: RateLimiterRes) => {
-        callback(new Error(`Too many failed logins`));
-      });
-  };
-
-  #onMailFrom: SMTPServerOptions['onMailFrom'] = (
-    address,
-    session,
-    callback,
-  ) => {
-    if (Config.isFromAllowed(address.address, session.user)) callback();
-    else callback(new Error(`FROM "${address.address}" not allowed`));
-  };
-
-  #onData: SMTPServerOptions['onData'] = (stream, session, callback) => {
-    if (!session.envelope.mailFrom) {
-      callback(new Error('Missing FROM'));
-      return;
     }
 
-    const sender = session.envelope.mailFrom.address;
-    const recipientCount = session.envelope.rcptTo.length;
-    let attachmentCount = 0;
-    let attachmentTotalSize = 0;
-    let attachmentMetricsErrorLogged = false;
-    log(
-      'verbose',
-      `Receiving message from "${sender}" to ${recipientCount} recipient${recipientCount === 1 ? '' : 's'}`,
-    );
+    listen()
+    {
+        return new Promise<void>((resolve, reject)=>{
+            this.#server.on('error', reject);
 
-    const mail = new MailComposer({
-      messageId: session.id,
-      raw: stream,
-    });
+            this.#server.listen(Config.smtpPort, Config.smtpListenIp, ()=>{
+                log('info', `Server started on ${Config.smtpListenIp || 'any-ip'}:${Config.smtpPort}`);
+                this.#server.off('error', reject);
+                this.#server.on('error', error=>{
+                    log('error', `An error occured`, {error});
+                });
+                resolve();
+            });
+        });
+    }
 
-    // Inject BCC header if necessary
-    const envelope = { ...session.envelope }; // We need a copy, because the envelope object will get overwritten while parsing
-    const splitter = new Splitter();
-    splitter.on('data', (data: any) => {
+    #onConnect: SMTPServerOptions['onConnect'] = (session, callback)=>
+    {
+        if(Config.isIpAllowed(session.remoteAddress))
+        {
+            this.#rateLimiter.consume('all').then((rateLimit)=>{
+                callback();
+            }).catch((rateLimit: RateLimiterRes)=>{
+                callback(new Error(`Rate limit exceeded. Try again in ${Math.ceil(rateLimit.msBeforeNext/1000)} seconds`));
+            });
+        }
+        else
+            callback(new Error(`IP ${session.remoteAddress} is not allowed to connect`));
+    };
+
+    #onAuth: SMTPServerOptions['onAuth'] = (auth, session, callback)=>
+    {
+        this.#authLimiter.consume(session.remoteAddress).then((rateLimit)=>{
+            if(!auth.username || !auth.password)
+                callback(new Error('Unsupported authentication method'));
+            else if(Config.isUserAllowed(auth.username, auth.password))
+                callback(null, {user: auth.username});
+            else
+                callback(new Error('Invalid login'));
+        }).catch((rateLimit: RateLimiterRes)=>{
+            callback(new Error(`Too many failed logins`));
+        });
+    };
+
+    #onMailFrom: SMTPServerOptions['onMailFrom'] = (address, session, callback)=>
+    {
+        if(Config.isFromAllowed(address.address, session.user))
+            callback();
+        else
+            callback(new Error(`FROM "${address.address}" not allowed`));
+    };
+
+    #onData: SMTPServerOptions['onData'] = (stream, session, callback)=>
+    {
+        if(!session.envelope.mailFrom)
+        {
+            callback(new Error('Missing FROM'));
+            return;
+        }
+        const sender = session.envelope.mailFrom.address;
+        const recipientCount = session.envelope.rcptTo.length;
+        let attachmentCount = 0;
+        let attachmentTotalSize = 0;
+        let attachmentMetricsErrorLogged = false;
+        log(
+        'verbose',
+        `Receiving message from "${sender}" to ${recipientCount} recipient${recipientCount === 1 ? '' : 's'}`,
+        );
+
+        const mail = new MailComposer({
+            messageId: session.id,
+            raw: stream,
+        });
+
+        // Inject BCC header if necessary
+        const envelope = {...session.envelope}; // We need a copy, because the envelope object will get overwritten while parsing
+        const splitter = new Splitter();
+        splitter.on('data', (data: any)=>{
       try {
         if (
-          data?.type === 'node' &&
+           (data.type === 'node') &&
           (data.disposition === 'attachment' || Boolean(data.filename))
         ) {
           attachmentCount++;
@@ -157,86 +148,68 @@ export class SMTPServer {
       }
 
       if (data.type === 'node') {
-        // Inject from header if needed
-        try {
-          if (!data.headers.hasHeader('From') && envelope.mailFrom)
-            data.headers.add('From', envelope.mailFrom.address);
-        } catch (error) {
-          log('error', `Failed to inject from header`, { error });
-        }
+                // Inject from header if needed
+                try {
+                    if(!data.headers.hasHeader('From') && envelope.mailFrom)
+                        data.headers.add('From', envelope.mailFrom.address);
+                } catch(error) {
+                    log('error', `Failed to inject from header`, {error});
+                }
 
-        // Inject bcc header if needed
-        try {
-          if (!data.headers.hasHeader('Bcc')) // We don't have a BCC header?
-          {
-            // Collect all TO and CC recipients
-            const visibleRecipients: Address[] = [];
-            if (data.headers.hasHeader('To'))
-              visibleRecipients.push(
-                ...addressparser(data.headers.get('To'), { flatten: true }),
-              );
-            if (data.headers.hasHeader('Cc'))
-              visibleRecipients.push(
-                ...addressparser(data.headers.get('Cc'), { flatten: true }),
-              );
+                // Inject bcc header if needed
+                try {
+                    if(!data.headers.hasHeader('Bcc')) // We don't have a BCC header?
+                    {
+                        // Collect all TO and CC recipients
+                        const visibleRecipients: Address[] = [];
+                        if(data.headers.hasHeader('To')) visibleRecipients.push(...addressparser(data.headers.get('To'), {flatten: true}));
+                        if(data.headers.hasHeader('Cc')) visibleRecipients.push(...addressparser(data.headers.get('Cc'), {flatten: true}));
 
-            // Check if there are recipients missing from TO/CC, in that case we add them as BCC
-            const bcc = envelope.rcptTo.filter(
-              (rcpt) =>
-                !visibleRecipients.some(
-                  (visible) =>
-                    visible.address.toLowerCase() ===
-                    rcpt.address.toLowerCase(),
-                ),
-            );
-            if (bcc.length)
-              data.headers.add('Bcc', bcc.map((r) => r.address).join(', '));
-          }
-        } catch (error) {
-          log('error', `Failed to inject BCC header`, { error });
-        }
-      }
-    });
+                        // Check if there are recipients missing from TO/CC, in that case we add them as BCC
+                        const bcc = envelope.rcptTo.filter(rcpt=>!visibleRecipients.some(visible=>visible.address.toLowerCase()===rcpt.address.toLowerCase()));
+                        if(bcc.length) data.headers.add('Bcc', bcc.map(r=>r.address).join(', '));
+                    }
+                } catch(error) {
+                    log('error', `Failed to inject BCC header`, {error});
+                }
+            }
+        });
 
-    // Create the EML file
-    const tmpFile = path.join(this.#queue.tempPath, `${session.id}.eml`);
-    const writeStream = fs.createWriteStream(tmpFile);
-    const mailCompile = mail.compile();
-    (mailCompile as any).keepBcc = true;
-    mailCompile
-      .createReadStream()
-      .pipe(splitter)
-      .pipe(new Joiner())
-      .pipe(writeStream);
+        // Create the EML file
+        const tmpFile = path.join(this.#queue.tempPath, `${session.id}.eml`);
+        const writeStream = fs.createWriteStream(tmpFile);
+        const mailCompile = mail.compile();
+        (mailCompile as any).keepBcc = true;
+        mailCompile.createReadStream().pipe(splitter).pipe(new Joiner()).pipe(writeStream);
 
-    // Windows can keep a handle open for a short time even after 'finish' fires.
-    // the rename that occurs in MailQueue.add must wait until the underlying
-    // file descriptor is closed, which is signalled by the 'close' event.
-    writeStream.on('close', () => {
-      if (stream.sizeExceeded) {
-        const err = new Error('Message exceeds fixed maximum message size');
-        (<any>err).responseCode = 552;
-        callback(err);
+        // Windows can keep a handle open for a short time even after 'finish' fires.
+        // the rename that occurs in MailQueue.add must wait until the underlying
+        // file descriptor is closed, which is signalled by the 'close' event.
+        writeStream.on('close', () => {
+            if(stream.sizeExceeded)
+            {
+                const err = new Error('Message exceeds fixed maximum message size');
+                (<any>err).responseCode = 552;
+                callback(err);
 
-        try {
-          fs.unlinkSync(tmpFile);
-        } catch {
-          // ignore, it may already be removed by cleanup logic
-        }
-      } else {
-        log(
-          'verbose',
-          `Received message from "${sender}" to ${recipientCount} recipient${recipientCount === 1 ? '' : 's'} with ${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'} totaling ${attachmentTotalSize} bytes`,
-        );
-        callback();
-        this.#queue.add(tmpFile);
-      }
-    });
+                try {
+                    fs.unlinkSync(tmpFile);
+                } catch {
+                    // ignore, it may already be removed by cleanup logic
+                }
+            }
+            else {
+        log('verbose',`Received message from "${sender}" to ${recipientCount} recipient${recipientCount === 1 ? '' : 's'} with ${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'} totaling ${attachmentTotalSize} bytes`);
+                callback();
+                this.#queue.add(tmpFile);
+            }
+        });
 
-    // ensure the stream is ended when the mail compiles (pipe will do this for us,
-    // but explictly listening for 'finish' lets us log/debug if needed)
-    writeStream.on('finish', () => {
-      log('verbose', 'EML write finished, waiting for close');
-    });
-  };
+        // ensure the stream is ended when the mail compiles (pipe will do this for us,
+        // but explictly listening for 'finish' lets us log/debug if needed)
+        writeStream.on('finish', ()=>{
+            log('verbose', 'EML write finished, waiting for close');
+        });
+    };
+    
 }

--- a/src/classes/SMTPServer.ts
+++ b/src/classes/SMTPServer.ts
@@ -12,171 +12,231 @@ import { MailQueue } from './MailQueue';
 
 const log = prefixedLog('SMTPServer');
 
-export class SMTPServer
-{
-    #server: NodeSMTP;
-    #queue: MailQueue;
-    #rateLimiter = new RateLimiterMemory({
-        duration: Config.smtpRateLimitDuration,
-        points: Config.smtpRateLimitLimit,
-    });
-    #authLimiter = new RateLimiterMemory({
-        duration: Config.smtpAuthLimitDuration,
-        points: Config.smtpAuthLimitLimit,
-    });
+export class SMTPServer {
+  #server: NodeSMTP;
+  #queue: MailQueue;
+  #rateLimiter = new RateLimiterMemory({
+    duration: Config.smtpRateLimitDuration,
+    points: Config.smtpRateLimitLimit,
+  });
+  #authLimiter = new RateLimiterMemory({
+    duration: Config.smtpAuthLimitDuration,
+    points: Config.smtpAuthLimitLimit,
+  });
 
-    constructor(queue: MailQueue)
-    {
-        this.#queue = queue;
-        this.#server = new NodeSMTP({
-            onConnect: this.#onConnect,
-            onAuth: this.#onAuth,
-            onMailFrom: this.#onMailFrom,
-            onData: this.#onData,
-            authOptional: !Config.smtpRequireAuth,
-            banner: Config.smtpBanner ?? `SMTP2Graph ${VERSION}`,
-            size: Config.smtpMaxSize,
-            secure: Config.smtpSecure,
-            key: Config.smtpTlsKey,
-            cert: Config.smtpTlsCert,
-            allowInsecureAuth: Config.smtpAllowTls?Config.smtpAllowInsecureAuth:true,
-            disabledCommands: Config.smtpAllowTls?undefined:['STARTTLS'],
+  constructor(queue: MailQueue) {
+    this.#queue = queue;
+    this.#server = new NodeSMTP({
+      onConnect: this.#onConnect,
+      onAuth: this.#onAuth,
+      onMailFrom: this.#onMailFrom,
+      onData: this.#onData,
+      authOptional: !Config.smtpRequireAuth,
+      banner: Config.smtpBanner ?? `SMTP2Graph ${VERSION}`,
+      size: Config.smtpMaxSize,
+      secure: Config.smtpSecure,
+      key: Config.smtpTlsKey,
+      cert: Config.smtpTlsCert,
+      allowInsecureAuth: Config.smtpAllowTls
+        ? Config.smtpAllowInsecureAuth
+        : true,
+      disabledCommands: Config.smtpAllowTls ? undefined : ['STARTTLS'],
+    });
+  }
+
+  listen() {
+    return new Promise<void>((resolve, reject) => {
+      this.#server.on('error', reject);
+
+      this.#server.listen(Config.smtpPort, Config.smtpListenIp, () => {
+        log(
+          'info',
+          `Server started on ${Config.smtpListenIp || 'any-ip'}:${Config.smtpPort}`,
+        );
+        this.#server.off('error', reject);
+        this.#server.on('error', (error) => {
+          log('error', `An error occured`, { error });
         });
+        resolve();
+      });
+    });
+  }
+
+  #onConnect: SMTPServerOptions['onConnect'] = (session, callback) => {
+    if (Config.isIpAllowed(session.remoteAddress)) {
+      this.#rateLimiter
+        .consume('all')
+        .then((rateLimit) => {
+          callback();
+        })
+        .catch((rateLimit: RateLimiterRes) => {
+          callback(
+            new Error(
+              `Rate limit exceeded. Try again in ${Math.ceil(rateLimit.msBeforeNext / 1000)} seconds`,
+            ),
+          );
+        });
+    } else
+      callback(
+        new Error(`IP ${session.remoteAddress} is not allowed to connect`),
+      );
+  };
+
+  #onAuth: SMTPServerOptions['onAuth'] = (auth, session, callback) => {
+    this.#authLimiter
+      .consume(session.remoteAddress)
+      .then((rateLimit) => {
+        if (!auth.username || !auth.password)
+          callback(new Error('Unsupported authentication method'));
+        else if (Config.isUserAllowed(auth.username, auth.password))
+          callback(null, { user: auth.username });
+        else callback(new Error('Invalid login'));
+      })
+      .catch((rateLimit: RateLimiterRes) => {
+        callback(new Error(`Too many failed logins`));
+      });
+  };
+
+  #onMailFrom: SMTPServerOptions['onMailFrom'] = (
+    address,
+    session,
+    callback,
+  ) => {
+    if (Config.isFromAllowed(address.address, session.user)) callback();
+    else callback(new Error(`FROM "${address.address}" not allowed`));
+  };
+
+  #onData: SMTPServerOptions['onData'] = (stream, session, callback) => {
+    if (!session.envelope.mailFrom) {
+      callback(new Error('Missing FROM'));
+      return;
     }
 
-    listen()
-    {
-        return new Promise<void>((resolve, reject)=>{
-            this.#server.on('error', reject);
+    const sender = session.envelope.mailFrom.address;
+    const recipientCount = session.envelope.rcptTo.length;
+    let attachmentCount = 0;
+    let attachmentTotalSize = 0;
+    let attachmentMetricsErrorLogged = false;
+    log(
+      'verbose',
+      `Receiving message from "${sender}" to ${recipientCount} recipient${recipientCount === 1 ? '' : 's'}`,
+    );
 
-            this.#server.listen(Config.smtpPort, Config.smtpListenIp, ()=>{
-                log('info', `Server started on ${Config.smtpListenIp || 'any-ip'}:${Config.smtpPort}`);
-                this.#server.off('error', reject);
-                this.#server.on('error', error=>{
-                    log('error', `An error occured`, {error});
-                });
-                resolve();
-            });
-        });
-    }
+    const mail = new MailComposer({
+      messageId: session.id,
+      raw: stream,
+    });
 
-    #onConnect: SMTPServerOptions['onConnect'] = (session, callback)=>
-    {
-        if(Config.isIpAllowed(session.remoteAddress))
-        {
-            this.#rateLimiter.consume('all').then((rateLimit)=>{
-                callback();
-            }).catch((rateLimit: RateLimiterRes)=>{
-                callback(new Error(`Rate limit exceeded. Try again in ${Math.ceil(rateLimit.msBeforeNext/1000)} seconds`));
-            });
-        }
-        else
-            callback(new Error(`IP ${session.remoteAddress} is not allowed to connect`));
-    };
-
-    #onAuth: SMTPServerOptions['onAuth'] = (auth, session, callback)=>
-    {
-        this.#authLimiter.consume(session.remoteAddress).then((rateLimit)=>{
-            if(!auth.username || !auth.password)
-                callback(new Error('Unsupported authentication method'));
-            else if(Config.isUserAllowed(auth.username, auth.password))
-                callback(null, {user: auth.username});
-            else
-                callback(new Error('Invalid login'));
-        }).catch((rateLimit: RateLimiterRes)=>{
-            callback(new Error(`Too many failed logins`));
-        });
-    };
-
-    #onMailFrom: SMTPServerOptions['onMailFrom'] = (address, session, callback)=>
-    {
-        if(Config.isFromAllowed(address.address, session.user))
-            callback();
-        else
-            callback(new Error(`FROM "${address.address}" not allowed`));
-    };
-
-    #onData: SMTPServerOptions['onData'] = (stream, session, callback)=>
-    {
-        if(!session.envelope.mailFrom)
-        {
-            callback(new Error('Missing FROM'));
-            return;
+    // Inject BCC header if necessary
+    const envelope = { ...session.envelope }; // We need a copy, because the envelope object will get overwritten while parsing
+    const splitter = new Splitter();
+    splitter.on('data', (data: any) => {
+      try {
+        if (
+          data?.type === 'node' &&
+          (data.disposition === 'attachment' || Boolean(data.filename))
+        ) {
+          attachmentCount++;
         }
 
-        const mail = new MailComposer({
-            messageId: session.id,
-            raw: stream,
-        });
+        if (
+          data?.type === 'body' &&
+          (data.node?.disposition === 'attachment' ||
+            Boolean(data.node?.filename))
+        ) {
+          if (Buffer.isBuffer(data.value))
+            attachmentTotalSize += data.value.length;
+          else if (typeof data.value === 'string')
+            attachmentTotalSize += Buffer.byteLength(data.value);
+        }
+      } catch (error) {
+        if (!attachmentMetricsErrorLogged) {
+          attachmentMetricsErrorLogged = true;
+          log('error', 'Failed to process attachment metrics', { error });
+        }
+      }
 
-        // Inject BCC header if necessary
-        const envelope = {...session.envelope}; // We need a copy, because the envelope object will get overwritten while parsing
-        const splitter = new Splitter();
-        splitter.on('data', (data: any)=>{
-            if(data.type === 'node')
-            {
-                // Inject from header if needed
-                try {
-                    if(!data.headers.hasHeader('From') && envelope.mailFrom)
-                        data.headers.add('From', envelope.mailFrom.address);
-                } catch(error) {
-                    log('error', `Failed to inject from header`, {error});
-                }
+      if (data.type === 'node') {
+        // Inject from header if needed
+        try {
+          if (!data.headers.hasHeader('From') && envelope.mailFrom)
+            data.headers.add('From', envelope.mailFrom.address);
+        } catch (error) {
+          log('error', `Failed to inject from header`, { error });
+        }
 
-                // Inject bcc header if needed
-                try {
-                    if(!data.headers.hasHeader('Bcc')) // We don't have a BCC header?
-                    {
-                        // Collect all TO and CC recipients
-                        const visibleRecipients: Address[] = [];
-                        if(data.headers.hasHeader('To')) visibleRecipients.push(...addressparser(data.headers.get('To'), {flatten: true}));
-                        if(data.headers.hasHeader('Cc')) visibleRecipients.push(...addressparser(data.headers.get('Cc'), {flatten: true}));
+        // Inject bcc header if needed
+        try {
+          if (!data.headers.hasHeader('Bcc')) // We don't have a BCC header?
+          {
+            // Collect all TO and CC recipients
+            const visibleRecipients: Address[] = [];
+            if (data.headers.hasHeader('To'))
+              visibleRecipients.push(
+                ...addressparser(data.headers.get('To'), { flatten: true }),
+              );
+            if (data.headers.hasHeader('Cc'))
+              visibleRecipients.push(
+                ...addressparser(data.headers.get('Cc'), { flatten: true }),
+              );
 
-                        // Check if there are recipients missing from TO/CC, in that case we add them as BCC
-                        const bcc = envelope.rcptTo.filter(rcpt=>!visibleRecipients.some(visible=>visible.address.toLowerCase()===rcpt.address.toLowerCase()));
-                        if(bcc.length) data.headers.add('Bcc', bcc.map(r=>r.address).join(', '));
-                    }
-                } catch(error) {
-                    log('error', `Failed to inject BCC header`, {error});
-                }
-            }
-        });
+            // Check if there are recipients missing from TO/CC, in that case we add them as BCC
+            const bcc = envelope.rcptTo.filter(
+              (rcpt) =>
+                !visibleRecipients.some(
+                  (visible) =>
+                    visible.address.toLowerCase() ===
+                    rcpt.address.toLowerCase(),
+                ),
+            );
+            if (bcc.length)
+              data.headers.add('Bcc', bcc.map((r) => r.address).join(', '));
+          }
+        } catch (error) {
+          log('error', `Failed to inject BCC header`, { error });
+        }
+      }
+    });
 
-        // Create the EML file
-        const tmpFile = path.join(this.#queue.tempPath, `${session.id}.eml`);
-        const writeStream = fs.createWriteStream(tmpFile);
-        const mailCompile = mail.compile();
-        (mailCompile as any).keepBcc = true;
-        mailCompile.createReadStream().pipe(splitter).pipe(new Joiner()).pipe(writeStream);
+    // Create the EML file
+    const tmpFile = path.join(this.#queue.tempPath, `${session.id}.eml`);
+    const writeStream = fs.createWriteStream(tmpFile);
+    const mailCompile = mail.compile();
+    (mailCompile as any).keepBcc = true;
+    mailCompile
+      .createReadStream()
+      .pipe(splitter)
+      .pipe(new Joiner())
+      .pipe(writeStream);
 
-        // Windows can keep a handle open for a short time even after 'finish' fires.
-        // the rename that occurs in MailQueue.add must wait until the underlying
-        // file descriptor is closed, which is signalled by the 'close' event.
-        writeStream.on('close', () => {
-            if(stream.sizeExceeded)
-            {
-                const err = new Error('Message exceeds fixed maximum message size');
-                (<any>err).responseCode = 552;
-                callback(err);
+    // Windows can keep a handle open for a short time even after 'finish' fires.
+    // the rename that occurs in MailQueue.add must wait until the underlying
+    // file descriptor is closed, which is signalled by the 'close' event.
+    writeStream.on('close', () => {
+      if (stream.sizeExceeded) {
+        const err = new Error('Message exceeds fixed maximum message size');
+        (<any>err).responseCode = 552;
+        callback(err);
 
-                try {
-                    fs.unlinkSync(tmpFile);
-                } catch {
-                    // ignore, it may already be removed by cleanup logic
-                }
-            }
-            else
-            {
-                callback();
-                this.#queue.add(tmpFile);
-            }
-        });
+        try {
+          fs.unlinkSync(tmpFile);
+        } catch {
+          // ignore, it may already be removed by cleanup logic
+        }
+      } else {
+        log(
+          'verbose',
+          `Received message from "${sender}" to ${recipientCount} recipient${recipientCount === 1 ? '' : 's'} with ${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'} totaling ${attachmentTotalSize} bytes`,
+        );
+        callback();
+        this.#queue.add(tmpFile);
+      }
+    });
 
-        // ensure the stream is ended when the mail compiles (pipe will do this for us,
-        // but explictly listening for 'finish' lets us log/debug if needed)
-        writeStream.on('finish', ()=>{
-            log('verbose', 'EML write finished, waiting for close');
-        });
-    };
-    
+    // ensure the stream is ended when the mail compiles (pipe will do this for us,
+    // but explictly listening for 'finish' lets us log/debug if needed)
+    writeStream.on('finish', () => {
+      log('verbose', 'EML write finished, waiting for close');
+    });
+  };
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,10 @@ module.exports = (env, argv) => ({
             VERSION: JSON.stringify(require("./package.json").version),
             DEBUG: (argv.mode!=='production'),
         }),
+        // chokidar optionally depends on macOS-native fsevents; ignore it to avoid bundling .node binaries
+        new webpack.IgnorePlugin({
+            resourceRegExp: /^fsevents$/,
+        }),
     ],
     devtool: argv.mode==='production'?undefined:'inline-source-map',
     performance: {


### PR DESCRIPTION
- Added more verbose logging with LOG_LEVEL as ENV:

```
 LOG_LEVEL=verbose node ../dist/server.js        
[2026-03-13 18:25:41] [info]: [SMTPServer] Server started on any-ip:25
[2026-03-13 18:25:45] [verbose]: [SMTPServer] Receiving message from "redacted" to 1 recipient
[2026-03-13 18:25:45] [verbose]: [SMTPServer] EML write finished, waiting for close
[2026-03-13 18:25:45] [verbose]: [SMTPServer] Received message from "redacted" to 1 recipient with 0 attachments totaling 0 bytes
[2026-03-13 18:25:45] [verbose]: [MailQueue] Moved file "wefk3rdrhdqva7xn.eml" to queue
[2026-03-13 18:25:45] [verbose]: [MailQueue] File "wefk3rdrhdqva7xn.eml" appeared in the queue
[2026-03-13 18:25:45] [verbose]: [Mailer] Preparing to send mail from file "mailroot/queue/wefk3rdrhdqva7xn.eml"
[2026-03-13 18:25:45] [verbose]: [Mailer] Resolved sender "redacted" from message headers
[2026-03-13 18:25:45] [verbose]: [Mailer] Acquiring Graph access token
[2026-03-13 18:25:45] [verbose]: [Mailer] Acquired Graph access token
[2026-03-13 18:25:45] [verbose]: [Mailer] Sending message as "redacted" via Microsoft Graph
[2026-03-13 18:25:45] [verbose]: [Mailer] Message sent successfully as "redacted"
```

- Also fixed non working macOS build.
- Improved Dockerfile for host independed build 
- fixed logging deadlock