### PR TITLE
feat: multi-account relay support and retro WebUI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM node:20-alpine
 ARG VERSION
 LABEL version="SMTP2Graph v${VERSION}"
 
+# Install runtime dependencies for WebUI (express, ajv are externals not bundled by webpack)
+COPY package.json package-lock.json /opt/smtp2graph/
+RUN cd /opt/smtp2graph && npm ci --omit=dev && rm package.json package-lock.json
+ENV NODE_PATH=/opt/smtp2graph/node_modules
+
 # Add SMTP2Graph binary
 COPY dist/server.js /bin/smtp2graph.js
 COPY docker/startup.sh /bin/
@@ -15,4 +20,5 @@ RUN chmod +x /bin/test.sh
 WORKDIR /data
 VOLUME /data
 EXPOSE 587
+EXPOSE 3000
 ENTRYPOINT startup.sh

--- a/config.example.yml
+++ b/config.example.yml
@@ -75,8 +75,47 @@ receive:
     duration: 30 # Time period in seconds (default: 60 = 1 minute)
     limit: 5 # Maximum number of attempts in the time period (default: 10)
 
+# Optional: Multiple relay accounts (replaces 'send' section when defined)
+# Each account has its own app registration, IP whitelist, and sender restrictions.
+# This works like IIS6 SMTP virtual servers — one SMTP2Graph instance, multiple tenants.
+# accounts:
+#   - name: contoso-relay
+#     appReg:
+#       tenant: contoso
+#       id: 01234567-89ab-cdef-0123-456789abcdef
+#       certificate:
+#         thumbprint: 0123456789ABCDEF0123456789ABCDEF01234567
+#         privateKeyPath: contoso-client.key
+#     allowedIPs:
+#       - 10.0.1.0/24
+#       - 192.168.1.50
+#     allowedFrom:
+#       - noreply@contoso.com
+#       - alerts@contoso.com
+#     forceMailbox: smtp-relay@contoso.com
+#     retryLimit: 3
+#     retryInterval: 5
+#
+#   - name: fabrikam-relay
+#     appReg:
+#       tenant: fabrikam
+#       id: fedcba98-7654-3210-fedc-ba9876543210
+#       secret: VGhpcyBpcyB2ZXJ5IHNlY3JldCE=
+#     allowedIPs:
+#       - 10.0.2.0/24
+#     allowedFrom:
+#       - notifications@fabrikam.com
+
+# Optional: WebUI for configuration management and health monitoring
+# webui:
+#   enabled: true
+#   port: 3000
+#   listenAddress: 127.0.0.1  # Use 0.0.0.0 for Docker or remote access
+#   username: admin
+#   password: changeme
+
 # Optional: HTTP proxy to use for outgoing communication
-httpProxy: 
+httpProxy:
   host: localhost # Hostname or IP for the proxy
   port: 3000 # Proxy port
   protocol: https # Optional: http or https (default: http)

--- a/config.schema.json
+++ b/config.schema.json
@@ -31,6 +31,14 @@
                 }
             },
             "required": ["send"]
+        },
+        {
+            "properties": {
+                "mode": {
+                    "const": "full"
+                }
+            },
+            "required": ["accounts"]
         }
     ],
     "definitions": {
@@ -283,6 +291,112 @@
                             "type": "integer"
                         }
                     }
+                }
+            }
+        },
+        "accounts": {
+            "title": "Relay accounts",
+            "description": "Multiple relay accounts with per-account app registrations, IP whitelists, and sender restrictions",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name", "appReg"],
+                "properties": {
+                    "name": {
+                        "title": "Account name",
+                        "description": "Human-readable label for this relay account",
+                        "type": "string"
+                    },
+                    "appReg": {
+                        "title": "Entra ID application registration",
+                        "type": "object",
+                        "required": ["tenant", "id"],
+                        "oneOf": [
+                            {"required": ["secret"]},
+                            {"required": ["certificate"]}
+                        ],
+                        "properties": {
+                            "tenant": {
+                                "title": "Tenant name or GUID",
+                                "type": "string"
+                            },
+                            "id": {
+                                "title": "Client ID",
+                                "type": "string"
+                            },
+                            "secret": {
+                                "title": "Client secret",
+                                "type": "string"
+                            },
+                            "certificate": {
+                                "title": "Client certificate",
+                                "type": "object",
+                                "required": ["thumbprint", "privateKeyPath"],
+                                "properties": {
+                                    "thumbprint": {"type": "string"},
+                                    "privateKeyPath": {"type": "string"}
+                                }
+                            }
+                        }
+                    },
+                    "allowedIPs": {
+                        "title": "Allowed sender IPs",
+                        "description": "IP addresses or CIDR ranges allowed to relay through this account",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "anyOf": [
+                                {"$ref": "#/definitions/ipaddress"},
+                                {"$ref": "#/definitions/ipCIDR"}
+                            ]
+                        }
+                    },
+                    "allowedFrom": {
+                        "allOf": [{"$ref": "#/definitions/emailArray"}],
+                        "title": "Allowed FROM addresses"
+                    },
+                    "forceMailbox": {
+                        "title": "Force sender mailbox",
+                        "type": "string"
+                    },
+                    "retryLimit": {
+                        "title": "Retry limit",
+                        "description": "Times to retry sending (0 = disable, default: 3)",
+                        "type": "integer"
+                    },
+                    "retryInterval": {
+                        "title": "Retry interval (minutes)",
+                        "description": "Default: 5",
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "webui": {
+            "title": "WebUI configuration",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "title": "Enable WebUI",
+                    "type": "boolean"
+                },
+                "port": {
+                    "title": "WebUI port",
+                    "description": "Default: 3000",
+                    "type": "integer"
+                },
+                "listenAddress": {
+                    "$ref": "#/definitions/ipaddress",
+                    "title": "WebUI listen address",
+                    "description": "Default: 0.0.0.0"
+                },
+                "username": {
+                    "title": "WebUI username",
+                    "type": "string"
+                },
+                "password": {
+                    "title": "WebUI password",
+                    "type": "string"
                 }
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@azure/msal-node": "^2.10.0",
+        "ajv": "^8.17.0",
         "async-mutex": "^0.4.0",
         "axios": "^1.6.5",
         "base64-stream": "^1.0.0",
         "chokidar": "^3.5.3",
+        "express": "^4.21.0",
         "ip-cidr": "^4.0.0",
         "mailsplit": "^5.4.0",
         "nodemailer": "^6.9.8",
@@ -27,6 +29,7 @@
         "@types/base64-stream": "^1.0.5",
         "@types/chai": "^4.3.11",
         "@types/chai-as-promised": "^7.1.8",
+        "@types/express": "^5.0.0",
         "@types/http-proxy": "^1.17.14",
         "@types/mailparser": "^3.4.4",
         "@types/mocha": "^10.0.6",
@@ -250,6 +253,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "4.3.11",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
@@ -263,6 +277,16 @@
       "dev": true,
       "dependencies": {
         "@types/chai": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -290,6 +314,38 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.14",
@@ -337,6 +393,41 @@
       "integrity": "sha512-fUWthHO9k9DSdPCSPRqcu6TWhYyxTBg382vlNIttSe9M7XfsT06y0f24KHXtbnijPGGRIcVvdKHTNikOI6qiHA==",
       "dev": true,
       "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
         "@types/node": "*"
       }
     },
@@ -576,6 +667,19 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -607,28 +711,19 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "peerDependencies": {
-        "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-colors": {
@@ -687,6 +782,12 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -751,6 +852,57 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -820,6 +972,44 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
@@ -1078,6 +1268,42 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -1186,6 +1412,25 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -1262,6 +1507,20 @@
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1269,6 +1528,12 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.630",
@@ -1286,6 +1551,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding-japanese": {
       "version": "2.0.0",
@@ -1332,11 +1606,41 @@
         "node": ">=4"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
       "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
       "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -1346,6 +1650,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1402,6 +1712,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -1417,17 +1736,94 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -1453,6 +1849,39 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -1513,6 +1942,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -1560,7 +2007,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1581,6 +2027,43 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -1642,6 +2125,18 @@
         "node": "*"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1657,11 +2152,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -1711,6 +2218,26 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
         "entities": "^4.4.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy": {
@@ -1802,6 +2329,15 @@
       },
       "engines": {
         "node": ">=16.14.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/ipv6-normalize": {
@@ -1997,10 +2533,10 @@
       "dev": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -2248,11 +2784,47 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -2265,6 +2837,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -2480,6 +3064,15 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -2506,6 +3099,30 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -2574,6 +3191,15 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2606,6 +3232,12 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "1.1.1",
@@ -2654,6 +3286,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -2664,6 +3309,7 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2676,6 +3322,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2685,10 +3346,46 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/rate-limiter-flexible": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-4.0.0.tgz",
       "integrity": "sha512-SkA18LEPqJJKHixi6E7tzBKTXbj9gu5wPyfTykPVRZR5JGSw0dMCjtZsjlfuabVY940pu28Wu87NZN4FhztnyQ=="
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/rcedit": {
       "version": "4.0.1",
@@ -2743,6 +3440,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2841,6 +3547,40 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/selderee": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
@@ -2867,6 +3607,45 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -2875,6 +3654,27 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -2907,6 +3707,78 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/simple-swizzle": {
@@ -2969,6 +3841,15 @@
       "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string_decoder": {
@@ -3147,6 +4028,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -3241,6 +4131,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
@@ -3265,6 +4168,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -3301,6 +4213,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -3309,6 +4222,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -3323,6 +4245,15 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/SMTP2Graph/SMTP2Graph#readme",
   "devDependencies": {
+    "@types/express": "^5.0.0",
     "@microsoft/microsoft-graph-types": "^2.40.0",
     "@types/base64-stream": "^1.0.5",
     "@types/chai": "^4.3.11",
@@ -56,6 +57,8 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
+    "ajv": "^8.17.0",
+    "express": "^4.21.0",
     "@azure/msal-node": "^2.10.0",
     "async-mutex": "^0.4.0",
     "axios": "^1.6.5",

--- a/src/classes/Config.ts
+++ b/src/classes/Config.ts
@@ -7,9 +7,42 @@ import { AxiosProxyConfig } from 'axios';
 const baseDir = process.argv.find(arg=>arg.startsWith('--baseDir=') && arg.length > 10)?.substring(10);
 if(baseDir) process.chdir(baseDir);
 
+export interface IAccount
+{
+    /** Human-readable name for this relay account (used in WebUI and logs) */
+    name: string;
+    appReg: {
+        tenant: string;
+        id: string;
+        secret?: string;
+        certificate?: {
+            thumbprint: string;
+            privateKeyPath: string;
+        };
+    };
+    /** IP addresses/CIDRs allowed to relay through this account */
+    allowedIPs?: string[];
+    /** FROM addresses this account can send as */
+    allowedFrom?: string[];
+    /** Always send from this mailbox (overrides FROM header) */
+    forceMailbox?: string;
+    /** Times to retry sending a message when it failed (0 = disable, default: 3) */
+    retryLimit?: number;
+    /** Minutes between retry attempts (default: 5) */
+    retryInterval?: number;
+}
+
 export interface IConfig
 {
     mode: 'full'|'receive'|'send';
+    accounts?: IAccount[];
+    webui?: {
+        enabled?: boolean;
+        port?: number;
+        listenAddress?: string;
+        username: string;
+        password: string;
+    };
     send?: {
         appReg: {
             /** The tenant name (the part that comes before .onmicrosoft.com) */
@@ -89,7 +122,25 @@ export class Config
         if(typeof this.mode !== 'string' || !['full','receive','send'].includes(this.mode))
             throw new InvalidConfig('Invalid "mode" config property');
 
-        if(this.mode !== 'receive') // We're also sending?
+        if(this.#config.accounts?.length)
+        {
+            for(const account of this.#config.accounts)
+            {
+                if(!isStringValue(account.name))
+                    throw new InvalidConfig('Each account must have a "name" property');
+                if(!isStringValue(account.appReg?.id))
+                    throw new InvalidConfig(`Account "${account.name}": missing "appReg.id"`);
+                if(!isStringValue(account.appReg?.secret) && !isStringValue(account.appReg?.certificate?.thumbprint))
+                    throw new InvalidConfig(`Account "${account.name}": missing "appReg.secret" or "appReg.certificate"`);
+                if(!isStringValue(account.appReg?.tenant))
+                    throw new InvalidConfig(`Account "${account.name}": missing "appReg.tenant"`);
+                if(account.appReg?.certificate?.privateKeyPath && !fs.existsSync(account.appReg.certificate.privateKeyPath))
+                    throw new InvalidConfig(`Account "${account.name}": key file "${account.appReg.certificate.privateKeyPath}" not found`);
+                if(account.retryInterval !== undefined && account.retryInterval < 1)
+                    throw new InvalidConfig(`Account "${account.name}": retryInterval must be >= 1`);
+            }
+        }
+        else if(this.mode !== 'receive') // Legacy single-account validation
         {
             if(!isStringValue(this.clientId))
                 throw new InvalidConfig('Missing "appReg.id" property');
@@ -99,6 +150,14 @@ export class Config
                 throw new InvalidConfig(`Client key file "${this.clientCertificateKeyPath}" could not be found`);
             else if(!isStringValue(this.clientTenant))
                 throw new InvalidConfig('Missing "appReg.tenant" property');
+        }
+
+        if(this.webuiEnabled)
+        {
+            if(!isStringValue(this.webuiUsername) || !isStringValue(this.webuiPassword))
+                throw new InvalidConfig('WebUI requires "webui.username" and "webui.password" when enabled');
+            if(this.#config.webui?.listenAddress && !IPCIDR.isValidAddress(this.#config.webui.listenAddress))
+                throw new InvalidConfig('WebUI "listenAddress" is not a valid IP address');
         }
         
         if(this.sendRetryInterval !== undefined && this.sendRetryInterval < 1)
@@ -135,6 +194,109 @@ export class Config
             throw new InvalidConfig(`Property "httpProxy.username" is defined without "httpProxy.password"`);
         else if(this.#config.httpProxy?.password && !this.#config.httpProxy.username)
             throw new InvalidConfig(`Property "httpProxy.password" is defined without "httpProxy.username"`);
+    }
+
+    /** Get all configured relay accounts. Falls back to legacy single-account config. */
+    static get accounts(): IAccount[]
+    {
+        if(this.#config.accounts?.length)
+            return this.#config.accounts;
+
+        // Backward compatibility: synthesize single account from legacy send config
+        if(this.#config.send?.appReg)
+        {
+            return [{
+                name: 'default',
+                appReg: this.#config.send.appReg,
+                forceMailbox: this.#config.send.forceMailbox,
+                retryLimit: this.#config.send.retryLimit,
+                retryInterval: this.#config.send.retryInterval,
+                // Legacy mode: use global ipWhitelist and allowedFrom
+                allowedIPs: this.#config.receive?.ipWhitelist,
+                allowedFrom: this.#config.receive?.allowedFrom,
+            }];
+        }
+
+        return [];
+    }
+
+    /** Find the first account that matches the given client IP and FROM address */
+    static findAccountForSender(clientIp: string, fromAddress: string): IAccount | undefined
+    {
+        for(const account of this.accounts)
+        {
+            // Check IP whitelist
+            if(account.allowedIPs?.length)
+            {
+                let ipAllowed = false;
+                for(const allowed of account.allowedIPs)
+                {
+                    if(IPCIDR.isValidCIDR(allowed))
+                    {
+                        if(new IPCIDR(allowed).contains(clientIp))
+                        {
+                            ipAllowed = true;
+                            break;
+                        }
+                    }
+                    else if(allowed === clientIp)
+                    {
+                        ipAllowed = true;
+                        break;
+                    }
+                }
+                if(!ipAllowed) continue;
+            }
+
+            // Check FROM address whitelist
+            if(account.allowedFrom?.length)
+            {
+                if(!account.allowedFrom.some(a => a.toLowerCase() === fromAddress.toLowerCase()))
+                    continue;
+            }
+
+            return account;
+        }
+
+        return undefined;
+    }
+
+    /** Check if an IP matches ANY account's allowedIPs */
+    static isIpAllowedByAnyAccount(clientIp: string): boolean
+    {
+        return this.accounts.some(account => {
+            if(!account.allowedIPs?.length) return true; // No IP restriction = all allowed
+            return account.allowedIPs.some(allowed => {
+                if(IPCIDR.isValidCIDR(allowed))
+                    return new IPCIDR(allowed).contains(clientIp);
+                return allowed === clientIp;
+            });
+        });
+    }
+
+    static get webuiEnabled(): boolean
+    {
+        return Boolean(this.#config.webui?.enabled);
+    }
+
+    static get webuiPort(): number
+    {
+        return this.#config.webui?.port ?? 3000;
+    }
+
+    static get webuiListenAddress(): string
+    {
+        return this.#config.webui?.listenAddress ?? '0.0.0.0';
+    }
+
+    static get webuiUsername(): string | undefined
+    {
+        return this.#config.webui?.username;
+    }
+
+    static get webuiPassword(): string | undefined
+    {
+        return this.#config.webui?.password;
     }
 
     static get mode()

--- a/src/classes/MailQueue.ts
+++ b/src/classes/MailQueue.ts
@@ -4,7 +4,7 @@ import chokidar from 'chokidar';
 import { Mutex } from 'async-mutex';
 import { Mailer } from './Mailer';
 import { prefixedLog } from './Logger';
-import { Config } from './Config';
+import { Config, IAccount } from './Config';
 import { UnrecoverableError } from './Constants';
 
 const log = prefixedLog('MailQueue');
@@ -44,6 +44,38 @@ export class MailQueue
         return this.#tempPath;
     }
 
+    get queuePath(): string
+    {
+        return this.#queuePath;
+    }
+
+    get failedPath(): string
+    {
+        return this.#failedPath;
+    }
+
+    get isPaused(): boolean
+    {
+        return this.#paused;
+    }
+
+    /** Queue statistics for health dashboard */
+    get queueStats(): {queued: number, failed: number, retrying: number, temp: number}
+    {
+        const countEml = (dir: string): number => {
+            try {
+                return fs.readdirSync(dir).filter(f => f.endsWith('.eml')).length;
+            } catch { return 0; }
+        };
+
+        return {
+            queued: countEml(this.#queuePath),
+            failed: countEml(this.#failedPath),
+            retrying: this.#retryQueue.size,
+            temp: countEml(this.#tempPath),
+        };
+    }
+
     #startWatcher()
     {
         if(this.#paused) return; // Don't start the watcher when it's paused
@@ -59,36 +91,87 @@ export class MailQueue
     {
         const filename = path.basename(filePath);
         log('verbose', `File "${filename}" appeared in the queue`);
-        
+
+        // Read sidecar metadata to determine which account to use
+        let account: IAccount | undefined;
+        const metaPath = filePath.replace(/\.eml$/, '.meta.json');
         try {
-            await Mailer.sendEml(filePath);
+            if(fs.existsSync(metaPath))
+            {
+                const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+                account = Config.accounts.find(a => a.name === meta.accountName);
+                if(!account)
+                    log('warn', `Account "${meta.accountName}" from sidecar not found in config, using first account`);
+            }
+        } catch(error) {
+            log('warn', `Failed to read sidecar for "${filename}"`, {error});
+        }
+
+        // Fallback to first account (or the only account in single-account mode)
+        if(!account)
+            account = Config.accounts[0];
+
+        if(!account)
+        {
+            log('error', `No relay account available for "${filename}"`);
+            return;
+        }
+
+        try {
+            await Mailer.sendEml(filePath, account);
             this.remove(filePath);
+            this.#removeSidecar(filePath);
             this.#removeFromRetryQueue(filename);
         } catch(error) {
-            log('error', `Failed to send message "${filename}"`, {error, filename});
+            log('error', `Failed to send message "${filename}" via account "${account.name}"`, {error, filename});
             if(!(error instanceof UnrecoverableError))
                 this.#addToRetryQueue(filename);
+            else
+                this.#moveToFailed(filename);
+        }
+    }
+
+    #removeSidecar(filePath: string)
+    {
+        const metaPath = filePath.replace(/\.eml$/, '.meta.json');
+        try {
+            if(fs.existsSync(metaPath))
+                fs.unlinkSync(metaPath);
+        } catch(error) {
+            log('warn', `Failed to remove sidecar for "${path.basename(filePath)}"`, {error});
+        }
+    }
+
+    #moveToFailed(filename: string)
+    {
+        try {
+            this.#retryQueue.delete(filename);
+            fs.renameSync(path.join(this.#queuePath, filename), path.join(this.#failedPath, filename));
+            const metaFile = filename.replace(/\.eml$/, '.meta.json');
+            const metaSrc = path.join(this.#queuePath, metaFile);
+            if(fs.existsSync(metaSrc))
+                fs.renameSync(metaSrc, path.join(this.#failedPath, metaFile));
+        } catch(error) {
+            log('error', `Error moving file "${filename}" to failed dir`, {error, filename});
         }
     }
 
     #addToRetryQueue(filename: string)
     {
-        if(Config.sendRetryLimit) // Retrying is enabled?
+        // Get retry limit from first account (or legacy config)
+        const retryLimit = Config.accounts[0]?.retryLimit ?? Config.sendRetryLimit;
+        if(retryLimit) // Retrying is enabled?
         {
             const data = this.#retryQueue.get(filename);
-            if(data && data.retryCount >= Config.sendRetryLimit) // This file is already in the queue and exceeded the retry limit?
+            if(data && data.retryCount >= retryLimit) // This file is already in the queue and exceeded the retry limit?
             {
-                try {
-                    this.#retryQueue.delete(filename); // Remove from queue
-                    fs.renameSync(path.join(this.#queuePath, filename), path.join(this.#failedPath, filename)); // Move to failed dir
-                } catch(error) {
-                    log('error', `Error moving file "${filename}" from queue to failed dir`, {error, filename});
-                }
+                this.#moveToFailed(filename);
             }
             else // This file should be retried
             {
+                const retryInterval = Config.accounts[0]?.retryInterval ?? Config.sendRetryInterval;
                 const retryAfter = new Date();
-                retryAfter.setMinutes(retryAfter.getMinutes()+Config.sendRetryInterval);
+                retryAfter.setMinutes(retryAfter.getMinutes()+retryInterval);
                 this.#retryQueue.set(filename, {retryAfter, retryCount: (data?.retryCount || 0)+1});
             }
 
@@ -137,9 +220,16 @@ export class MailQueue
         const filename = path.basename(filePath);
         const dest = path.join(this.#queuePath, filename);
 
+        // Also move the sidecar .meta.json if it exists
+        const metaSrc = filePath.replace(/\.eml$/, '.meta.json');
+        const metaDest = dest.replace(/\.eml$/, '.meta.json');
+
         const attempt = (tries = 0) => {
             try {
                 fs.renameSync(filePath, dest);
+                // Move sidecar if it exists
+                if(fs.existsSync(metaSrc))
+                    fs.renameSync(metaSrc, metaDest);
                 log('verbose', `Moved file "${filename}" to queue`);
             } catch(error: any) {
                 // On Windows the file may still be locked for a brief moment after

--- a/src/classes/Mailer.ts
+++ b/src/classes/Mailer.ts
@@ -5,7 +5,7 @@ import axios, { AxiosRequestConfig, AxiosResponse, isAxiosError } from 'axios';
 import { Base64Encode } from 'base64-stream';
 import addressparser from 'nodemailer/lib/addressparser';
 import { ConfidentialClientApplication } from '@azure/msal-node';
-import { Config } from './Config';
+import { Config, IAccount } from './Config';
 import { UnrecoverableError } from './Constants';
 import { MsalProxy } from './MsalProxy';
 
@@ -20,24 +20,46 @@ export class Mailer
     /** Prevent sending more than 4 messages in parallel (see: https://learn.microsoft.com/en-us/graph/throttling-limits#outlook-service-limits) */
     static #sendSemaphore = new Semaphore(4);
 
-    static #msalClient = (Config.clientId && (Config.clientSecret || (Config.clientCertificateThumbprint && Config.clientCertificateKeyPath)))?new ConfidentialClientApplication({
-        auth: {
-            authority: Config.msalAuthority,
-            clientId: Config.clientId,
-            clientSecret: Config.clientSecret,
-            clientCertificate: Config.clientCertificateThumbprint && Config.clientCertificateKeyPath?{
-                thumbprint: Config.clientCertificateThumbprint,
-                privateKey: Config.clientCertificateKey!,
-            }:undefined,
-        },
-        system: Config.httpProxyConfig?{networkClient: new MsalProxy()}:undefined, // We use our custom implementation, because the `proxyUrl` property doesn't want to work
-    }):undefined;
+    static #msalClients = new Map<string, ConfidentialClientApplication>();
 
-    static async sendEml(filePath: string)
+    static #getClient(account: IAccount): ConfidentialClientApplication
+    {
+        let client = this.#msalClients.get(account.name);
+        if(!client)
+        {
+            const certKeyPath = account.appReg.certificate?.privateKeyPath;
+            const certKey = certKeyPath && fs.existsSync(certKeyPath)
+                ? fs.readFileSync(certKeyPath).toString()
+                : undefined;
+
+            const tenantId = account.appReg.tenant;
+            const authority = /^[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}$/i.test(tenantId)
+                ? `https://login.microsoftonline.com/${tenantId}`
+                : `https://login.microsoftonline.com/${tenantId}.onmicrosoft.com`;
+
+            client = new ConfidentialClientApplication({
+                auth: {
+                    authority,
+                    clientId: account.appReg.id,
+                    clientSecret: account.appReg.secret,
+                    clientCertificate: account.appReg.certificate ? {
+                        thumbprint: account.appReg.certificate.thumbprint,
+                        privateKey: certKey!,
+                    } : undefined,
+                },
+                system: Config.httpProxyConfig ? {networkClient: new MsalProxy()} : undefined,
+            });
+
+            this.#msalClients.set(account.name, client);
+        }
+        return client;
+    }
+
+    static async sendEml(filePath: string, account: IAccount)
     {
         return this.#sendSemaphore.runExclusive(async ()=>{
             // Determine the sender
-            let sender = Config.forceMailbox;
+            let sender = account.forceMailbox;
             if(!sender) // There's no forced sender in the config, so we get it from the mail data
             {
                 const senderObj = await this.#findSender(filePath);
@@ -46,7 +68,7 @@ export class Mailer
             }
 
             // Fetch an accesstoken if needed
-            const token = await this.#aquireToken();
+            const token = await this.#aquireToken(account);
 
             // Send the message
             const readStream = fs.createReadStream(filePath);
@@ -169,16 +191,26 @@ export class Mailer
         readStream.destroy();
     }
 
-    static async #aquireToken(): Promise<string>
+    static async #aquireToken(account: IAccount): Promise<string>
     {
         return this.#aquireTokenMutex.runExclusive(async ()=>{
-            if(!this.#msalClient) throw new UnrecoverableError('Trying to login without an application registration');
-
-            const res = await this.#msalClient.acquireTokenByClientCredential({
+            const client = this.#getClient(account);
+            const res = await client.acquireTokenByClientCredential({
                 scopes: ['https://graph.microsoft.com/.default'],
             });
             return res?.accessToken!;
         });
+    }
+
+    /** Test if we can acquire a token for the given account (used by health dashboard) */
+    static async testConnection(account: IAccount): Promise<{ok: boolean, error?: string}>
+    {
+        try {
+            await this.#aquireToken(account);
+            return {ok: true};
+        } catch(error: any) {
+            return {ok: false, error: String(error)};
+        }
     }
 
 }

--- a/src/classes/SMTPServer.ts
+++ b/src/classes/SMTPServer.ts
@@ -60,18 +60,31 @@ export class SMTPServer
         });
     }
 
+    get isListening(): boolean
+    {
+        return this.#server.server.listening;
+    }
+
     #onConnect: SMTPServerOptions['onConnect'] = (session, callback)=>
     {
-        if(Config.isIpAllowed(session.remoteAddress))
+        if(!Config.isIpAllowed(session.remoteAddress))
         {
-            this.#rateLimiter.consume('all').then((rateLimit)=>{
-                callback();
-            }).catch((rateLimit: RateLimiterRes)=>{
-                callback(new Error(`Rate limit exceeded. Try again in ${Math.ceil(rateLimit.msBeforeNext/1000)} seconds`));
-            });
-        }
-        else
             callback(new Error(`IP ${session.remoteAddress} is not allowed to connect`));
+            return;
+        }
+
+        // Multi-account check: does any account accept this IP?
+        if(Config.accounts.length > 0 && !Config.isIpAllowedByAnyAccount(session.remoteAddress))
+        {
+            callback(new Error(`IP ${session.remoteAddress} has no relay account configured`));
+            return;
+        }
+
+        this.#rateLimiter.consume('all').then(()=>{
+            callback();
+        }).catch((rateLimit: RateLimiterRes)=>{
+            callback(new Error(`Rate limit exceeded. Try again in ${Math.ceil(rateLimit.msBeforeNext/1000)} seconds`));
+        });
     };
 
     #onAuth: SMTPServerOptions['onAuth'] = (auth, session, callback)=>
@@ -90,10 +103,26 @@ export class SMTPServer
 
     #onMailFrom: SMTPServerOptions['onMailFrom'] = (address, session, callback)=>
     {
-        if(Config.isFromAllowed(address.address, session.user))
-            callback();
-        else
+        if(!Config.isFromAllowed(address.address, session.user))
+        {
             callback(new Error(`FROM "${address.address}" not allowed`));
+            return;
+        }
+
+        // Multi-account routing: find matching account
+        if(Config.accounts.length > 0)
+        {
+            const account = Config.findAccountForSender(session.remoteAddress, address.address);
+            if(!account)
+            {
+                callback(new Error(`No relay account configured for "${address.address}" from IP ${session.remoteAddress}`));
+                return;
+            }
+            (session as any).matchedAccount = account;
+            log('verbose', `Matched account "${account.name}" for ${address.address} from ${session.remoteAddress}`);
+        }
+
+        callback();
     };
 
     #onData: SMTPServerOptions['onData'] = (stream, session, callback)=>
@@ -167,6 +196,23 @@ export class SMTPServer
             }
             else
             {
+                // Write sidecar metadata file for multi-account routing
+                const matchedAccount = (session as any).matchedAccount;
+                if(matchedAccount)
+                {
+                    const metaFile = tmpFile.replace(/\.eml$/, '.meta.json');
+                    try {
+                        fs.writeFileSync(metaFile, JSON.stringify({
+                            accountName: matchedAccount.name,
+                            clientIp: session.remoteAddress,
+                            fromAddress: session.envelope.mailFrom?.address,
+                            timestamp: new Date().toISOString(),
+                        }));
+                    } catch(error) {
+                        log('error', `Failed to write metadata file`, {error});
+                    }
+                }
+
                 callback();
                 this.#queue.add(tmpFile);
             }

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,19 @@ else
             log('error', `Failed to start SMTP server. ${String(error)}`, {error});
             process.exit(1);
         }
+
+        // Start WebUI if enabled
+        if(Config.webuiEnabled)
+        {
+            try {
+                const { WebServer } = await import('./webui/WebServer');
+                const webServer = new WebServer(queue, server);
+                await webServer.listen();
+            } catch(error) {
+                log('error', `Failed to start WebUI. ${String(error)}`, {error});
+                // Don't exit — SMTP relay still works without WebUI
+            }
+        }
     })();
 }
 

--- a/src/webui/WebServer.ts
+++ b/src/webui/WebServer.ts
@@ -1,0 +1,86 @@
+import express, { Request, Response, NextFunction } from 'express';
+import { Config } from '../classes/Config';
+import { prefixedLog } from '../classes/Logger';
+import { MailQueue } from '../classes/MailQueue';
+import { SMTPServer } from '../classes/SMTPServer';
+import { configRoutes } from './routes/configRoutes';
+import { healthRoutes } from './routes/healthRoutes';
+import { accountRoutes } from './routes/accountRoutes';
+
+const log = prefixedLog('WebUI');
+
+export class WebServer
+{
+    #app: express.Application;
+    #queue: MailQueue;
+    #smtpServer: SMTPServer;
+
+    constructor(queue: MailQueue, smtpServer: SMTPServer)
+    {
+        this.#queue = queue;
+        this.#smtpServer = smtpServer;
+        this.#app = express();
+
+        this.#setupMiddleware();
+        this.#setupRoutes();
+    }
+
+    #setupMiddleware()
+    {
+        // JSON body parser
+        this.#app.use(express.json());
+
+        // Basic Auth
+        this.#app.use((req: Request, res: Response, next: NextFunction) => {
+            const auth = req.headers.authorization;
+            if(!auth || !auth.startsWith('Basic '))
+            {
+                res.setHeader('WWW-Authenticate', 'Basic realm="SMTP2Graph WebUI"');
+                res.status(401).send('Authentication required');
+                return;
+            }
+
+            const decoded = Buffer.from(auth.substring(6), 'base64').toString();
+            const colonIdx = decoded.indexOf(':');
+            const username = decoded.substring(0, colonIdx);
+            const password = decoded.substring(colonIdx + 1);
+
+            if(username === Config.webuiUsername && password === Config.webuiPassword)
+                next();
+            else
+            {
+                res.setHeader('WWW-Authenticate', 'Basic realm="SMTP2Graph WebUI"');
+                res.status(401).send('Invalid credentials');
+            }
+        });
+    }
+
+    #setupRoutes()
+    {
+        // API routes
+        this.#app.use('/api', configRoutes());
+        this.#app.use('/api', healthRoutes(this.#queue, this.#smtpServer));
+        this.#app.use('/api', accountRoutes());
+
+        // Static files — serve embedded HTML/JS/CSS
+        this.#app.get('/', (req, res) => {
+            res.type('html').send(require('./public/index.html'));
+        });
+        this.#app.get('/app.js', (req, res) => {
+            res.type('js').send(require('./public/app.js'));
+        });
+        this.#app.get('/style.css', (req, res) => {
+            res.type('css').send(require('./public/style.css'));
+        });
+    }
+
+    listen(): Promise<void>
+    {
+        return new Promise((resolve) => {
+            this.#app.listen(Config.webuiPort, Config.webuiListenAddress, () => {
+                log('info', `WebUI started on ${Config.webuiListenAddress}:${Config.webuiPort}`);
+                resolve();
+            });
+        });
+    }
+}

--- a/src/webui/public/app.js
+++ b/src/webui/public/app.js
@@ -1,0 +1,493 @@
+/* =============================================
+   SMTP2Graph WebUI — Frontend Logic
+   ============================================= */
+
+(function() {
+    'use strict';
+
+    // State
+    let currentTab = 'dashboard';
+    let healthPollInterval = null;
+    let editingAccount = null; // null = adding new, string = editing existing
+
+    // ---- Tab Navigation ----
+    document.querySelectorAll('.tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+            switchTab(tab.dataset.tab);
+        });
+    });
+
+    function switchTab(tabName) {
+        currentTab = tabName;
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.add('hidden'));
+        document.querySelector('.tab[data-tab="' + tabName + '"]').classList.add('active');
+        document.getElementById('tab-' + tabName).classList.remove('hidden');
+
+        if(tabName === 'dashboard') startHealthPolling();
+        else stopHealthPolling();
+
+        if(tabName === 'accounts') loadAccounts();
+        if(tabName === 'config') loadConfig();
+    }
+
+    // ---- Dashboard ----
+    function startHealthPolling() {
+        fetchHealth();
+        fetchLogs();
+        healthPollInterval = setInterval(() => {
+            fetchHealth();
+            fetchLogs();
+        }, 10000);
+    }
+
+    function stopHealthPolling() {
+        if(healthPollInterval) {
+            clearInterval(healthPollInterval);
+            healthPollInterval = null;
+        }
+    }
+
+    async function fetchHealth() {
+        try {
+            const res = await fetch('/api/health');
+            const data = await res.json();
+            updateDashboard(data);
+            setStatus('Health data refreshed');
+        } catch(err) {
+            setStatus('Failed to fetch health data');
+        }
+    }
+
+    function updateDashboard(data) {
+        // SMTP Status
+        const smtpIcon = document.getElementById('smtp-icon');
+        const smtpText = document.getElementById('smtp-status-text');
+        if(data.smtp.listening) {
+            smtpIcon.className = 'status-icon ok';
+            smtpText.textContent = 'Running';
+        } else {
+            smtpIcon.className = 'status-icon error';
+            smtpText.textContent = 'Stopped';
+        }
+        document.getElementById('smtp-port').textContent = data.smtp.port;
+        document.getElementById('smtp-mode').textContent = data.smtp.mode;
+        document.getElementById('smtp-uptime').textContent = formatUptime(data.uptime);
+        document.getElementById('smtp-version').textContent = 'v' + data.version;
+
+        // Queue
+        document.getElementById('queue-queued').textContent = data.queue.queued;
+        document.getElementById('queue-retrying').textContent = data.queue.retrying;
+        document.getElementById('queue-failed').textContent = data.queue.failed;
+        document.getElementById('queue-temp').textContent = data.queue.temp;
+
+        // Account Health Cards
+        const container = document.getElementById('account-cards');
+        container.innerHTML = '';
+        if(data.accounts.length === 0) {
+            container.innerHTML = '<p class="placeholder">No accounts configured</p>';
+            return;
+        }
+        data.accounts.forEach(acct => {
+            const card = document.createElement('div');
+            card.className = 'account-card';
+            const iconClass = acct.graphApi.ok ? 'ok' : 'error';
+            const statusText = acct.graphApi.ok ? 'Connected' : (acct.graphApi.error || 'Error');
+            card.innerHTML =
+                '<div class="card-title">' + escapeHtml(acct.name) + '</div>' +
+                '<div class="card-body">' +
+                    '<div class="detail-row">' +
+                        '<span>Tenant:</span><span>' + escapeHtml(acct.tenant) + '</span>' +
+                    '</div>' +
+                    '<div class="detail-row">' +
+                        '<span>Graph API:</span>' +
+                        '<span><span class="status-icon ' + iconClass + '">&#9679;</span> ' + escapeHtml(statusText) + '</span>' +
+                    '</div>' +
+                '</div>';
+            container.appendChild(card);
+        });
+    }
+
+    async function fetchLogs() {
+        try {
+            const res = await fetch('/api/logs?lines=50');
+            const entries = await res.json();
+            const logContent = document.getElementById('log-content');
+            logContent.textContent = entries.map(e => {
+                const ts = e.timestamp || '';
+                const level = (e.level || '').toUpperCase().padEnd(7);
+                return '[' + ts + '] ' + level + ' ' + (e.message || JSON.stringify(e));
+            }).join('\n');
+
+            // Auto-scroll to bottom
+            const logArea = document.getElementById('log-area');
+            logArea.scrollTop = logArea.scrollHeight;
+        } catch(err) {
+            // silent
+        }
+    }
+
+    // ---- Accounts Tab ----
+    async function loadAccounts() {
+        try {
+            const res = await fetch('/api/accounts');
+            const accounts = await res.json();
+            renderAccountsList(accounts);
+            setStatus(accounts.length + ' account(s) loaded');
+        } catch(err) {
+            setStatus('Failed to load accounts');
+        }
+    }
+
+    function renderAccountsList(accounts) {
+        const body = document.getElementById('accounts-rows');
+        body.innerHTML = '';
+
+        if(accounts.length === 0) {
+            body.innerHTML = '<p class="placeholder">No accounts configured. Click "Add Account" to create one.</p>';
+            return;
+        }
+
+        accounts.forEach(acct => {
+            const row = document.createElement('div');
+            row.className = 'listview-row';
+            const ipsText = acct.allowedIPs.length ? acct.allowedIPs.join(', ') : 'Any';
+            const fromText = acct.allowedFrom.length ? acct.allowedFrom.join(', ') : 'Any';
+            row.innerHTML =
+                '<span class="col-name">' + escapeHtml(acct.name) + '</span>' +
+                '<span class="col-tenant">' + escapeHtml(acct.tenant) + '</span>' +
+                '<span class="col-auth">' + (acct.hasCertificate ? 'Cert' : 'Secret') + '</span>' +
+                '<span class="col-ips" title="' + escapeHtml(acct.allowedIPs.join(', ')) + '">' + escapeHtml(ipsText) + '</span>' +
+                '<span class="col-from" title="' + escapeHtml(acct.allowedFrom.join(', ')) + '">' + escapeHtml(fromText) + '</span>' +
+                '<span class="col-actions">' +
+                    '<button class="btn btn-test" data-name="' + escapeHtml(acct.name) + '">Test</button>' +
+                    '<button class="btn btn-edit" data-name="' + escapeHtml(acct.name) + '">Edit</button>' +
+                    '<button class="btn btn-delete" data-name="' + escapeHtml(acct.name) + '">Del</button>' +
+                '</span>';
+            body.appendChild(row);
+        });
+
+        // Event listeners
+        body.querySelectorAll('.btn-test').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                testAccount(btn.dataset.name);
+            });
+        });
+        body.querySelectorAll('.btn-edit').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                editAccount(btn.dataset.name);
+            });
+        });
+        body.querySelectorAll('.btn-delete').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                deleteAccount(btn.dataset.name);
+            });
+        });
+    }
+
+    async function testAccount(name) {
+        setStatus('Testing connectivity for "' + name + '"...');
+        try {
+            const res = await fetch('/api/accounts/' + encodeURIComponent(name) + '/test');
+            const result = await res.json();
+            if(result.ok)
+                showAlert('Connection Test', 'Account "' + name + '" connected successfully!');
+            else
+                showAlert('Connection Test', 'Account "' + name + '" failed: ' + result.error);
+        } catch(err) {
+            showAlert('Error', 'Failed to test account: ' + err.message);
+        }
+    }
+
+    async function editAccount(name) {
+        try {
+            const res = await fetch('/api/accounts?showSecrets=true');
+            const accounts = await res.json();
+            const acct = accounts.find(a => a.name === name);
+            if(!acct) { showAlert('Error', 'Account not found'); return; }
+
+            editingAccount = name;
+            document.getElementById('dialog-title').textContent = 'Edit Account: ' + name;
+            document.getElementById('acct-name').value = acct.name;
+            document.getElementById('acct-tenant').value = acct.tenant;
+            document.getElementById('acct-client-id').value = acct.clientId;
+            document.getElementById('acct-secret').value = acct.secret || '';
+            document.getElementById('acct-cert-thumbprint').value = '';
+            document.getElementById('acct-cert-key-path').value = '';
+            document.getElementById('acct-allowed-ips').value = acct.allowedIPs.join('\n');
+            document.getElementById('acct-allowed-from').value = acct.allowedFrom.join('\n');
+            document.getElementById('acct-force-mailbox').value = acct.forceMailbox || '';
+            document.getElementById('acct-retry-limit').value = acct.retryLimit;
+            document.getElementById('acct-retry-interval').value = acct.retryInterval;
+
+            document.getElementById('account-dialog-overlay').classList.remove('hidden');
+        } catch(err) {
+            showAlert('Error', 'Failed to load account: ' + err.message);
+        }
+    }
+
+    async function deleteAccount(name) {
+        if(!confirm('Delete account "' + name + '"? This requires a restart to take effect.')) return;
+        try {
+            const res = await fetch('/api/accounts/' + encodeURIComponent(name), {method: 'DELETE'});
+            const result = await res.json();
+            if(result.success) {
+                showAlert('Success', result.message);
+                loadAccounts();
+            } else {
+                showAlert('Error', (result.errors && result.errors.join('\n')) || 'Failed to delete');
+            }
+        } catch(err) {
+            showAlert('Error', 'Failed to delete account: ' + err.message);
+        }
+    }
+
+    // Add Account button
+    document.getElementById('btn-add-account').addEventListener('click', () => {
+        editingAccount = null;
+        document.getElementById('dialog-title').textContent = 'Add Relay Account';
+        document.querySelectorAll('#account-dialog .field').forEach(f => {
+            if(f.tagName === 'TEXTAREA') f.value = '';
+            else if(f.type === 'number') { /* keep defaults */ }
+            else f.value = '';
+        });
+        document.getElementById('account-dialog-overlay').classList.remove('hidden');
+    });
+
+    document.getElementById('btn-refresh-accounts').addEventListener('click', loadAccounts);
+
+    // Dialog save
+    document.getElementById('btn-dialog-save').addEventListener('click', async () => {
+        const account = buildAccountFromForm();
+        const method = editingAccount ? 'PUT' : 'POST';
+        const url = editingAccount
+            ? '/api/accounts/' + encodeURIComponent(editingAccount)
+            : '/api/accounts';
+
+        try {
+            const res = await fetch(url, {
+                method,
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(account),
+            });
+            const result = await res.json();
+            if(result.success) {
+                document.getElementById('account-dialog-overlay').classList.add('hidden');
+                showAlert('Success', result.message);
+                loadAccounts();
+            } else {
+                showAlert('Validation Error', (result.errors && result.errors.join('\n')) || 'Invalid account configuration');
+            }
+        } catch(err) {
+            showAlert('Error', 'Failed to save account: ' + err.message);
+        }
+    });
+
+    document.getElementById('btn-dialog-cancel').addEventListener('click', () => {
+        document.getElementById('account-dialog-overlay').classList.add('hidden');
+    });
+
+    document.getElementById('dialog-close').addEventListener('click', () => {
+        document.getElementById('account-dialog-overlay').classList.add('hidden');
+    });
+
+    function buildAccountFromForm() {
+        const ips = document.getElementById('acct-allowed-ips').value.trim().split('\n').filter(l => l.trim());
+        const froms = document.getElementById('acct-allowed-from').value.trim().split('\n').filter(l => l.trim());
+        const secret = document.getElementById('acct-secret').value.trim();
+        const thumbprint = document.getElementById('acct-cert-thumbprint').value.trim();
+        const keyPath = document.getElementById('acct-cert-key-path').value.trim();
+
+        const account = {
+            name: document.getElementById('acct-name').value.trim(),
+            appReg: {
+                tenant: document.getElementById('acct-tenant').value.trim(),
+                id: document.getElementById('acct-client-id').value.trim(),
+            },
+            allowedIPs: ips.length ? ips : undefined,
+            allowedFrom: froms.length ? froms : undefined,
+            forceMailbox: document.getElementById('acct-force-mailbox').value.trim() || undefined,
+            retryLimit: parseInt(document.getElementById('acct-retry-limit').value) || 3,
+            retryInterval: parseInt(document.getElementById('acct-retry-interval').value) || 5,
+        };
+
+        if(secret)
+            account.appReg.secret = secret;
+        if(thumbprint && keyPath)
+            account.appReg.certificate = {thumbprint, privateKeyPath: keyPath};
+
+        return account;
+    }
+
+    // ---- Config Tab ----
+    async function loadConfig() {
+        try {
+            const res = await fetch('/api/config');
+            const config = await res.json();
+            renderConfigForm(config);
+            setStatus('Configuration loaded');
+        } catch(err) {
+            setStatus('Failed to load configuration');
+        }
+    }
+
+    function renderConfigForm(config) {
+        const container = document.getElementById('config-form');
+        container.innerHTML = '';
+
+        // Mode
+        addConfigSection(container, 'Operation Mode', [
+            {key: 'mode', label: 'Mode', type: 'select', options: ['full', 'receive', 'send'], value: config.mode},
+        ]);
+
+        // SMTP (receive) settings
+        if(config.receive) {
+            addConfigSection(container, 'SMTP Server (Receive)', [
+                {key: 'receive.port', label: 'Port', type: 'number', value: config.receive.port || 25},
+                {key: 'receive.listenAddress', label: 'Listen Address', type: 'text', value: config.receive.listenAddress || ''},
+                {key: 'receive.secure', label: 'Require TLS', type: 'checkbox', value: config.receive.secure || false},
+                {key: 'receive.maxSize', label: 'Max Message Size', type: 'text', value: config.receive.maxSize || '100m'},
+                {key: 'receive.banner', label: 'SMTP Banner', type: 'text', value: config.receive.banner || ''},
+                {key: 'receive.requireAuth', label: 'Require Auth', type: 'checkbox', value: config.receive.requireAuth || false},
+            ]);
+        }
+
+        // HTTP Proxy
+        if(config.httpProxy) {
+            addConfigSection(container, 'HTTP Proxy', [
+                {key: 'httpProxy.host', label: 'Host', type: 'text', value: config.httpProxy.host || ''},
+                {key: 'httpProxy.port', label: 'Port', type: 'number', value: config.httpProxy.port || ''},
+                {key: 'httpProxy.protocol', label: 'Protocol', type: 'select', options: ['http', 'https'], value: config.httpProxy.protocol || 'http'},
+            ]);
+        }
+
+        // WebUI settings
+        if(config.webui) {
+            addConfigSection(container, 'WebUI', [
+                {key: 'webui.enabled', label: 'Enabled', type: 'checkbox', value: config.webui.enabled || false},
+                {key: 'webui.port', label: 'Port', type: 'number', value: config.webui.port || 3000},
+                {key: 'webui.listenAddress', label: 'Listen Address', type: 'text', value: config.webui.listenAddress || '0.0.0.0'},
+            ]);
+        }
+    }
+
+    function addConfigSection(container, title, fields) {
+        const section = document.createElement('div');
+        section.className = 'group-box config-section';
+        let html = '<legend>' + escapeHtml(title) + '</legend>';
+
+        fields.forEach(f => {
+            html += '<div class="form-group">';
+            html += '<label>' + escapeHtml(f.label) + ':</label>';
+
+            if(f.type === 'select') {
+                html += '<select class="field" data-key="' + f.key + '">';
+                f.options.forEach(opt => {
+                    html += '<option value="' + opt + '"' + (opt === f.value ? ' selected' : '') + '>' + opt + '</option>';
+                });
+                html += '</select>';
+            } else if(f.type === 'checkbox') {
+                html += '<input type="checkbox" data-key="' + f.key + '"' + (f.value ? ' checked' : '') + '>';
+            } else {
+                html += '<input type="' + f.type + '" class="field" data-key="' + f.key + '" value="' + escapeHtml(String(f.value || '')) + '">';
+            }
+
+            html += '</div>';
+        });
+
+        section.innerHTML = html;
+        container.appendChild(section);
+    }
+
+    document.getElementById('btn-save-config').addEventListener('click', async () => {
+        try {
+            // Read current config with secrets, then apply form changes
+            const res = await fetch('/api/config?showSecrets=true');
+            const config = await res.json();
+
+            // Apply form values
+            document.querySelectorAll('#config-form [data-key]').forEach(el => {
+                const keys = el.dataset.key.split('.');
+                let obj = config;
+                for(let i = 0; i < keys.length - 1; i++) {
+                    if(!obj[keys[i]]) obj[keys[i]] = {};
+                    obj = obj[keys[i]];
+                }
+                const lastKey = keys[keys.length - 1];
+                if(el.type === 'checkbox')
+                    obj[lastKey] = el.checked;
+                else if(el.type === 'number')
+                    obj[lastKey] = el.value ? parseInt(el.value) : undefined;
+                else
+                    obj[lastKey] = el.value || undefined;
+            });
+
+            const saveRes = await fetch('/api/config', {
+                method: 'PUT',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(config),
+            });
+            const result = await saveRes.json();
+
+            if(result.success) {
+                document.getElementById('restart-banner').classList.remove('hidden');
+                setStatus('Configuration saved');
+            } else {
+                showAlert('Validation Error', (result.errors && result.errors.join('\n')) || 'Invalid configuration');
+            }
+        } catch(err) {
+            showAlert('Error', 'Failed to save config: ' + err.message);
+        }
+    });
+
+    document.getElementById('btn-reload-config').addEventListener('click', loadConfig);
+
+    // ---- Alert Dialog ----
+    function showAlert(title, message) {
+        document.getElementById('alert-title').textContent = title;
+        document.getElementById('alert-message').textContent = message;
+        document.getElementById('alert-dialog-overlay').classList.remove('hidden');
+    }
+
+    document.getElementById('alert-ok').addEventListener('click', () => {
+        document.getElementById('alert-dialog-overlay').classList.add('hidden');
+    });
+    document.getElementById('alert-close').addEventListener('click', () => {
+        document.getElementById('alert-dialog-overlay').classList.add('hidden');
+    });
+
+    // ---- Status Bar ----
+    function setStatus(text) {
+        document.getElementById('statusbar-text').textContent = text;
+    }
+
+    // Clock
+    function updateClock() {
+        const now = new Date();
+        document.getElementById('statusbar-time').textContent = now.toLocaleTimeString();
+    }
+    setInterval(updateClock, 1000);
+    updateClock();
+
+    // ---- Utilities ----
+    function formatUptime(seconds) {
+        const d = Math.floor(seconds / 86400);
+        const h = Math.floor((seconds % 86400) / 3600);
+        const m = Math.floor((seconds % 3600) / 60);
+        if(d > 0) return d + 'd ' + h + 'h ' + m + 'm';
+        if(h > 0) return h + 'h ' + m + 'm';
+        return m + 'm';
+    }
+
+    function escapeHtml(str) {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+
+    // ---- Init ----
+    switchTab('dashboard');
+})();

--- a/src/webui/public/index.html
+++ b/src/webui/public/index.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SMTP2Graph Control Panel</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+    <div class="desktop">
+        <div class="window" id="main-window">
+            <div class="title-bar">
+                <span class="title-bar-text">SMTP2Graph Control Panel</span>
+                <div class="title-bar-controls">
+                    <button class="title-btn minimize-btn"></button>
+                    <button class="title-btn maximize-btn"></button>
+                    <button class="title-btn close-btn"></button>
+                </div>
+            </div>
+
+            <div class="menu-bar">
+                <span class="menu-item">File</span>
+                <span class="menu-item">View</span>
+                <span class="menu-item">Help</span>
+            </div>
+
+            <div class="tab-bar">
+                <button class="tab active" data-tab="dashboard">System Monitor</button>
+                <button class="tab" data-tab="accounts">Network Accounts</button>
+                <button class="tab" data-tab="config">System Properties</button>
+            </div>
+
+            <div class="tab-content" id="tab-dashboard">
+                <div class="panel-row">
+                    <div class="group-box" id="smtp-status">
+                        <legend>SMTP Server Status</legend>
+                        <div class="status-row">
+                            <span class="status-icon" id="smtp-icon">&#9679;</span>
+                            <span id="smtp-status-text">Checking...</span>
+                        </div>
+                        <div class="detail-row">
+                            <span>Port:</span> <span id="smtp-port">&mdash;</span>
+                        </div>
+                        <div class="detail-row">
+                            <span>Mode:</span> <span id="smtp-mode">&mdash;</span>
+                        </div>
+                        <div class="detail-row">
+                            <span>Uptime:</span> <span id="smtp-uptime">&mdash;</span>
+                        </div>
+                        <div class="detail-row">
+                            <span>Version:</span> <span id="smtp-version">&mdash;</span>
+                        </div>
+                    </div>
+
+                    <div class="group-box" id="queue-status">
+                        <legend>Mail Queue</legend>
+                        <div class="detail-row">
+                            <span>Queued:</span> <span id="queue-queued">&mdash;</span>
+                        </div>
+                        <div class="detail-row">
+                            <span>Retrying:</span> <span id="queue-retrying">&mdash;</span>
+                        </div>
+                        <div class="detail-row">
+                            <span>Failed:</span> <span id="queue-failed">&mdash;</span>
+                        </div>
+                        <div class="detail-row">
+                            <span>In progress:</span> <span id="queue-temp">&mdash;</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="group-box" id="accounts-health">
+                    <legend>Relay Account Health</legend>
+                    <div id="account-cards" class="account-cards">
+                        <p class="placeholder">Loading...</p>
+                    </div>
+                </div>
+
+                <div class="group-box" id="log-viewer">
+                    <legend>Recent Activity</legend>
+                    <div class="log-area" id="log-area">
+                        <pre id="log-content">Loading logs...</pre>
+                    </div>
+                </div>
+            </div>
+
+            <div class="tab-content hidden" id="tab-accounts">
+                <div class="toolbar">
+                    <button class="btn" id="btn-add-account">Add Account</button>
+                    <button class="btn" id="btn-refresh-accounts">Refresh</button>
+                </div>
+
+                <div class="listview" id="accounts-list">
+                    <div class="listview-header">
+                        <span class="col-name">Name</span>
+                        <span class="col-tenant">Tenant</span>
+                        <span class="col-auth">Auth</span>
+                        <span class="col-ips">Allowed IPs</span>
+                        <span class="col-from">Allowed From</span>
+                        <span class="col-actions">Actions</span>
+                    </div>
+                    <div id="accounts-rows" class="listview-body">
+                        <p class="placeholder">Loading...</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="tab-content hidden" id="tab-config">
+                <div class="toolbar">
+                    <button class="btn" id="btn-save-config">Save</button>
+                    <button class="btn" id="btn-reload-config">Reload</button>
+                </div>
+                <div id="restart-banner" class="alert-banner hidden">
+                    &#9888; Configuration changed. Restart SMTP2Graph for changes to take effect.
+                </div>
+                <div id="config-form" class="config-form">
+                    <p class="placeholder">Loading configuration...</p>
+                </div>
+            </div>
+
+            <div class="status-bar">
+                <span id="statusbar-text">Ready</span>
+                <span id="statusbar-time"></span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Account Edit Dialog -->
+    <div class="dialog-overlay hidden" id="account-dialog-overlay">
+        <div class="window dialog" id="account-dialog">
+            <div class="title-bar">
+                <span class="title-bar-text" id="dialog-title">Add Relay Account</span>
+                <div class="title-bar-controls">
+                    <button class="title-btn close-btn" id="dialog-close"></button>
+                </div>
+            </div>
+            <div class="dialog-body">
+                <div class="form-group">
+                    <label>Account Name:</label>
+                    <input type="text" id="acct-name" class="field">
+                </div>
+                <div class="form-group">
+                    <label>Tenant:</label>
+                    <input type="text" id="acct-tenant" class="field" placeholder="contoso or GUID">
+                </div>
+                <div class="form-group">
+                    <label>Client ID:</label>
+                    <input type="text" id="acct-client-id" class="field">
+                </div>
+                <div class="form-group">
+                    <label>Client Secret:</label>
+                    <input type="password" id="acct-secret" class="field" placeholder="Leave blank for certificate auth">
+                </div>
+                <div class="form-group">
+                    <label>Certificate Thumbprint:</label>
+                    <input type="text" id="acct-cert-thumbprint" class="field">
+                </div>
+                <div class="form-group">
+                    <label>Private Key Path:</label>
+                    <input type="text" id="acct-cert-key-path" class="field">
+                </div>
+                <div class="form-group">
+                    <label>Allowed IPs (one per line):</label>
+                    <textarea id="acct-allowed-ips" class="field" rows="4" placeholder="10.0.1.0/24&#10;192.168.1.50"></textarea>
+                </div>
+                <div class="form-group">
+                    <label>Allowed FROM Addresses (one per line):</label>
+                    <textarea id="acct-allowed-from" class="field" rows="4" placeholder="noreply@contoso.com&#10;alerts@contoso.com"></textarea>
+                </div>
+                <div class="form-group">
+                    <label>Force Mailbox (optional):</label>
+                    <input type="text" id="acct-force-mailbox" class="field">
+                </div>
+                <div class="form-row">
+                    <div class="form-group half">
+                        <label>Retry Limit:</label>
+                        <input type="number" id="acct-retry-limit" class="field" value="3">
+                    </div>
+                    <div class="form-group half">
+                        <label>Retry Interval (min):</label>
+                        <input type="number" id="acct-retry-interval" class="field" value="5">
+                    </div>
+                </div>
+                <div class="dialog-buttons">
+                    <button class="btn" id="btn-dialog-save">OK</button>
+                    <button class="btn" id="btn-dialog-cancel">Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Alert Dialog -->
+    <div class="dialog-overlay hidden" id="alert-dialog-overlay">
+        <div class="window dialog dialog-sm" id="alert-dialog">
+            <div class="title-bar">
+                <span class="title-bar-text" id="alert-title">SMTP2Graph</span>
+                <div class="title-bar-controls">
+                    <button class="title-btn close-btn" id="alert-close"></button>
+                </div>
+            </div>
+            <div class="dialog-body">
+                <p id="alert-message"></p>
+                <div class="dialog-buttons">
+                    <button class="btn" id="alert-ok">OK</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="/app.js"></script>
+</body>
+</html>

--- a/src/webui/public/style.css
+++ b/src/webui/public/style.css
@@ -1,0 +1,506 @@
+/* =============================================
+   SMTP2Graph WebUI — Retro OS Theme
+   Inspired by Mac OS 9 / Windows 98
+   ============================================= */
+
+/* Reset & Base */
+*, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: "Chicago", "MS Sans Serif", "Tahoma", "Geneva", sans-serif;
+    font-size: 11px;
+    background: #008080;
+    color: #000;
+    overflow: hidden;
+    height: 100vh;
+}
+
+/* Desktop */
+.desktop {
+    width: 100vw;
+    height: 100vh;
+    padding: 8px;
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+}
+
+/* Window */
+.window {
+    background: #c0c0c0;
+    border: 2px outset #dfdfdf;
+    box-shadow: 2px 2px 0 #000;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 1100px;
+}
+
+/* Title Bar */
+.title-bar {
+    background: linear-gradient(90deg, #000080, #1084d0);
+    color: #fff;
+    padding: 2px 4px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: bold;
+    font-size: 12px;
+    user-select: none;
+}
+
+.title-bar-text {
+    flex: 1;
+    padding-left: 2px;
+}
+
+.title-bar-controls {
+    display: flex;
+    gap: 2px;
+}
+
+.title-btn {
+    width: 16px;
+    height: 14px;
+    background: #c0c0c0;
+    border: 1px outset #dfdfdf;
+    font-size: 8px;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.title-btn:active {
+    border-style: inset;
+}
+
+.minimize-btn::after { content: "\2013"; }
+.maximize-btn::after { content: "\25A1"; }
+.close-btn::after { content: "\00D7"; font-size: 10px; }
+
+/* Menu Bar */
+.menu-bar {
+    background: #c0c0c0;
+    border-bottom: 1px solid #808080;
+    padding: 2px 4px;
+    display: flex;
+    gap: 8px;
+}
+
+.menu-item {
+    padding: 1px 6px;
+    cursor: default;
+}
+
+.menu-item:hover {
+    background: #000080;
+    color: #fff;
+}
+
+/* Tab Bar */
+.tab-bar {
+    background: #c0c0c0;
+    padding: 6px 6px 0 6px;
+    display: flex;
+    gap: 0;
+    border-bottom: 2px solid #c0c0c0;
+}
+
+.tab {
+    background: #c0c0c0;
+    border: 1px solid #808080;
+    border-bottom: none;
+    padding: 4px 16px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 11px;
+    position: relative;
+    top: 2px;
+    margin-right: -1px;
+}
+
+.tab.active {
+    background: #c0c0c0;
+    border-top: 2px solid #dfdfdf;
+    border-left: 2px solid #dfdfdf;
+    border-right: 2px solid #808080;
+    border-bottom: 2px solid #c0c0c0;
+    z-index: 1;
+    font-weight: bold;
+}
+
+/* Tab Content */
+.tab-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px;
+    background: #c0c0c0;
+    border-top: 1px solid #808080;
+}
+
+.tab-content.hidden {
+    display: none;
+}
+
+/* Group Box (etched fieldset) */
+.group-box {
+    border: 2px groove #dfdfdf;
+    padding: 8px;
+    margin-bottom: 8px;
+    position: relative;
+}
+
+.group-box legend {
+    background: #c0c0c0;
+    padding: 0 4px;
+    font-weight: bold;
+    font-size: 11px;
+}
+
+/* Buttons */
+.btn {
+    background: #c0c0c0;
+    border: 2px outset #dfdfdf;
+    padding: 3px 12px;
+    font-family: inherit;
+    font-size: 11px;
+    cursor: pointer;
+    min-width: 75px;
+}
+
+.btn:hover {
+    background: #d4d4d4;
+}
+
+.btn:active {
+    border-style: inset;
+    padding: 4px 11px 2px 13px;
+}
+
+.btn:focus {
+    outline: 1px dotted #000;
+    outline-offset: -4px;
+}
+
+/* Input Fields */
+.field {
+    background: #fff;
+    border: 2px inset #c0c0c0;
+    padding: 2px 4px;
+    font-family: inherit;
+    font-size: 11px;
+    width: 100%;
+}
+
+textarea.field {
+    resize: vertical;
+    font-family: "Courier New", monospace;
+}
+
+/* Status Row */
+.status-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    margin-bottom: 4px;
+}
+
+.status-icon {
+    font-size: 14px;
+}
+
+.status-icon.ok { color: #008000; }
+.status-icon.error { color: #ff0000; }
+.status-icon.warning { color: #ff8c00; }
+
+.detail-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 1px 0;
+    border-bottom: 1px dotted #a0a0a0;
+}
+
+/* Panel Row (side by side) */
+.panel-row {
+    display: flex;
+    gap: 8px;
+}
+
+.panel-row > .group-box {
+    flex: 1;
+}
+
+/* Account Cards */
+.account-cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.account-card {
+    border: 2px outset #dfdfdf;
+    background: #c0c0c0;
+    width: 220px;
+}
+
+.account-card .card-title {
+    background: linear-gradient(90deg, #000080, #1084d0);
+    color: #fff;
+    padding: 2px 4px;
+    font-size: 11px;
+    font-weight: bold;
+}
+
+.account-card .card-body {
+    padding: 6px;
+}
+
+.account-card .card-body .detail-row {
+    font-size: 10px;
+}
+
+/* Log Area */
+.log-area {
+    background: #000;
+    color: #00ff00;
+    border: 2px inset #808080;
+    padding: 4px;
+    height: 200px;
+    overflow-y: auto;
+    font-family: "Courier New", "Lucida Console", monospace;
+    font-size: 10px;
+}
+
+.log-area pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+/* Toolbar */
+.toolbar {
+    display: flex;
+    gap: 4px;
+    padding: 4px 0;
+    border-bottom: 1px solid #808080;
+    margin-bottom: 8px;
+}
+
+/* Listview */
+.listview {
+    border: 2px inset #c0c0c0;
+    background: #fff;
+}
+
+.listview-header {
+    display: flex;
+    background: #c0c0c0;
+    border-bottom: 2px outset #dfdfdf;
+    font-weight: bold;
+    font-size: 11px;
+}
+
+.listview-header span {
+    padding: 2px 8px;
+    border-right: 1px solid #808080;
+    flex-shrink: 0;
+}
+
+.col-name { width: 140px; }
+.col-tenant { width: 120px; }
+.col-auth { width: 80px; }
+.col-ips { flex: 1; min-width: 160px; }
+.col-from { flex: 1; min-width: 160px; }
+.col-actions { width: 160px; }
+
+.listview-body {
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+.listview-row {
+    display: flex;
+    padding: 2px 0;
+    border-bottom: 1px solid #e0e0e0;
+    align-items: center;
+    cursor: default;
+}
+
+.listview-row:nth-child(even) {
+    background: #f0f0f0;
+}
+
+.listview-row:hover {
+    background: #000080;
+    color: #fff;
+}
+
+.listview-row span {
+    padding: 2px 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.listview-row .col-actions {
+    display: flex;
+    gap: 4px;
+    padding: 2px 4px;
+}
+
+.listview-row .col-actions .btn {
+    min-width: auto;
+    padding: 1px 6px;
+    font-size: 10px;
+}
+
+/* Status Bar */
+.status-bar {
+    background: #c0c0c0;
+    border-top: 2px groove #dfdfdf;
+    padding: 2px 8px;
+    display: flex;
+    justify-content: space-between;
+    font-size: 10px;
+}
+
+/* Dialog Overlay */
+.dialog-overlay {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+}
+
+.dialog-overlay.hidden {
+    display: none;
+}
+
+.dialog {
+    width: 450px;
+    max-height: 80vh;
+    box-shadow: 4px 4px 0 #000;
+}
+
+.dialog-sm {
+    width: 320px;
+}
+
+.dialog-body {
+    padding: 12px;
+    overflow-y: auto;
+}
+
+.dialog-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+/* Form */
+.form-group {
+    margin-bottom: 8px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 2px;
+    font-weight: bold;
+}
+
+.form-row {
+    display: flex;
+    gap: 8px;
+}
+
+.form-group.half {
+    flex: 1;
+}
+
+/* Config Form */
+.config-form {
+    max-height: 500px;
+    overflow-y: auto;
+}
+
+.config-section {
+    margin-bottom: 12px;
+}
+
+.config-section h3 {
+    font-size: 11px;
+    padding: 2px 4px;
+    background: #c0c0c0;
+    border: 1px solid #808080;
+    margin-bottom: 4px;
+}
+
+/* Alert Banner */
+.alert-banner {
+    background: #ffffe1;
+    border: 2px outset #dfdfdf;
+    padding: 6px 10px;
+    margin-bottom: 8px;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.alert-banner.hidden {
+    display: none;
+}
+
+/* Placeholder */
+.placeholder {
+    color: #808080;
+    padding: 8px;
+    text-align: center;
+    font-style: italic;
+}
+
+/* Scrollbar styling (Webkit) */
+::-webkit-scrollbar {
+    width: 16px;
+    height: 16px;
+}
+
+::-webkit-scrollbar-track {
+    background: #c0c0c0;
+    border: 1px inset #dfdfdf;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #c0c0c0;
+    border: 2px outset #dfdfdf;
+}
+
+::-webkit-scrollbar-button {
+    background: #c0c0c0;
+    border: 2px outset #dfdfdf;
+    width: 16px;
+    height: 16px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .panel-row {
+        flex-direction: column;
+    }
+    .account-card {
+        width: 100%;
+    }
+    .listview-header, .listview-row {
+        font-size: 10px;
+    }
+}

--- a/src/webui/routes/accountRoutes.ts
+++ b/src/webui/routes/accountRoutes.ts
@@ -1,0 +1,109 @@
+import { Router } from 'express';
+import { Config } from '../../classes/Config';
+import { Mailer } from '../../classes/Mailer';
+import { ConfigService } from '../services/ConfigService';
+
+export function accountRoutes(): Router
+{
+    const router = Router();
+    const configService = new ConfigService();
+
+    // List all accounts
+    router.get('/accounts', (req, res) => {
+        const showSecrets = req.query.showSecrets === 'true';
+        const accounts = Config.accounts.map(account => ({
+            name: account.name,
+            tenant: account.appReg.tenant,
+            clientId: account.appReg.id,
+            hasSecret: Boolean(account.appReg.secret),
+            hasCertificate: Boolean(account.appReg.certificate),
+            allowedIPs: account.allowedIPs || [],
+            allowedFrom: account.allowedFrom || [],
+            forceMailbox: account.forceMailbox,
+            retryLimit: account.retryLimit ?? 3,
+            retryInterval: account.retryInterval ?? 5,
+            // Only show secrets if requested
+            ...(showSecrets ? {secret: account.appReg.secret} : {}),
+        }));
+        res.json(accounts);
+    });
+
+    // Test connectivity for a specific account
+    router.get('/accounts/:name/test', async (req, res) => {
+        const account = Config.accounts.find(a => a.name === req.params.name);
+        if(!account)
+        {
+            res.status(404).json({error: `Account "${req.params.name}" not found`});
+            return;
+        }
+
+        const result = await Mailer.testConnection(account);
+        res.json(result);
+    });
+
+    // Add new account (writes to config.yml)
+    router.post('/accounts', (req, res) => {
+        try {
+            const config = configService.getConfig(true);
+            if(!config.accounts) config.accounts = [];
+            config.accounts.push(req.body);
+            const result = configService.updateConfig(config);
+            if(result.success)
+                res.json({success: true, message: 'Account added. Restart required.'});
+            else
+                res.status(400).json({success: false, errors: result.errors});
+        } catch(error) {
+            res.status(500).json({error: 'Failed to add account'});
+        }
+    });
+
+    // Update existing account
+    router.put('/accounts/:name', (req, res) => {
+        try {
+            const config = configService.getConfig(true);
+            if(!config.accounts) config.accounts = [];
+            const idx = config.accounts.findIndex((a: any) => a.name === req.params.name);
+            if(idx === -1)
+            {
+                res.status(404).json({error: `Account "${req.params.name}" not found`});
+                return;
+            }
+            config.accounts[idx] = req.body;
+            const result = configService.updateConfig(config);
+            if(result.success)
+                res.json({success: true, message: 'Account updated. Restart required.'});
+            else
+                res.status(400).json({success: false, errors: result.errors});
+        } catch(error) {
+            res.status(500).json({error: 'Failed to update account'});
+        }
+    });
+
+    // Delete account
+    router.delete('/accounts/:name', (req, res) => {
+        try {
+            const config = configService.getConfig(true);
+            if(!config.accounts)
+            {
+                res.status(404).json({error: 'No accounts configured'});
+                return;
+            }
+            const idx = config.accounts.findIndex((a: any) => a.name === req.params.name);
+            if(idx === -1)
+            {
+                res.status(404).json({error: `Account "${req.params.name}" not found`});
+                return;
+            }
+            config.accounts.splice(idx, 1);
+            const result = configService.updateConfig(config);
+            if(result.success)
+                res.json({success: true, message: 'Account removed. Restart required.'});
+            else
+                res.status(400).json({success: false, errors: result.errors});
+        } catch(error) {
+            res.status(500).json({error: 'Failed to delete account'});
+        }
+    });
+
+    return router;
+}

--- a/src/webui/routes/configRoutes.ts
+++ b/src/webui/routes/configRoutes.ts
@@ -1,0 +1,44 @@
+import { Router } from 'express';
+import { ConfigService } from '../services/ConfigService';
+
+export function configRoutes(): Router
+{
+    const router = Router();
+    const configService = new ConfigService();
+
+    // Get current config
+    router.get('/config', (req, res) => {
+        try {
+            const showSecrets = req.query.showSecrets === 'true';
+            const config = configService.getConfig(showSecrets);
+            res.json(config);
+        } catch(error) {
+            res.status(500).json({error: 'Failed to read config'});
+        }
+    });
+
+    // Update config
+    router.put('/config', (req, res) => {
+        try {
+            const result = configService.updateConfig(req.body);
+            if(result.success)
+                res.json({success: true, message: 'Config saved. Restart required for changes to take effect.'});
+            else
+                res.status(400).json({success: false, errors: result.errors});
+        } catch(error) {
+            res.status(500).json({error: 'Failed to save config'});
+        }
+    });
+
+    // Get JSON schema
+    router.get('/config/schema', (req, res) => {
+        try {
+            const schema = configService.getSchema();
+            res.json(schema);
+        } catch(error) {
+            res.status(500).json({error: 'Failed to read schema'});
+        }
+    });
+
+    return router;
+}

--- a/src/webui/routes/healthRoutes.ts
+++ b/src/webui/routes/healthRoutes.ts
@@ -1,0 +1,74 @@
+import { Router } from 'express';
+import { MailQueue } from '../../classes/MailQueue';
+import { SMTPServer } from '../../classes/SMTPServer';
+import { Mailer } from '../../classes/Mailer';
+import { Config } from '../../classes/Config';
+import fs from 'fs';
+import path from 'path';
+
+export function healthRoutes(queue: MailQueue, smtpServer: SMTPServer): Router
+{
+    const router = Router();
+
+    // Overall health status
+    router.get('/health', async (req, res) => {
+        const accountHealth = [];
+        for(const account of Config.accounts)
+        {
+            const connectivity = await Mailer.testConnection(account);
+            accountHealth.push({
+                name: account.name,
+                tenant: account.appReg.tenant,
+                graphApi: connectivity,
+            });
+        }
+
+        res.json({
+            smtp: {
+                listening: smtpServer.isListening,
+                port: Config.smtpPort,
+                mode: Config.mode,
+            },
+            accounts: accountHealth,
+            queue: queue.queueStats,
+            paused: queue.isPaused,
+            uptime: process.uptime(),
+            version: VERSION,
+        });
+    });
+
+    // Queue statistics
+    router.get('/queue', (req, res) => {
+        res.json(queue.queueStats);
+    });
+
+    // Recent log entries
+    router.get('/logs', (req, res) => {
+        const lines = parseInt(req.query.lines as string) || 100;
+        const logFile = path.join('logs', 'combined.log');
+
+        try {
+            if(!fs.existsSync(logFile))
+            {
+                res.json([]);
+                return;
+            }
+
+            const content = fs.readFileSync(logFile, 'utf-8');
+            const allLines = content.trim().split('\n').filter(l => l);
+            const recent = allLines.slice(-lines);
+
+            // Parse JSON log entries
+            const entries = recent.map(line => {
+                try { return JSON.parse(line); }
+                catch { return {message: line}; }
+            });
+
+            res.json(entries);
+        } catch(error) {
+            res.status(500).json({error: 'Failed to read logs'});
+        }
+    });
+
+    return router;
+}

--- a/src/webui/services/ConfigService.ts
+++ b/src/webui/services/ConfigService.ts
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import Ajv from 'ajv';
+
+export class ConfigService
+{
+    #configFile: string;
+    #schemaFile: string;
+
+    constructor(configFile: string = 'config.yml', schemaFile: string = 'config.schema.json')
+    {
+        this.#configFile = configFile;
+        this.#schemaFile = schemaFile;
+    }
+
+    getConfig(showSecrets: boolean = false): any
+    {
+        const content = fs.readFileSync(this.#configFile, 'utf-8');
+        const config = parseYaml(content);
+
+        if(!showSecrets)
+            this.#maskSecrets(config);
+
+        return config;
+    }
+
+    getSchema(): any
+    {
+        const content = fs.readFileSync(this.#schemaFile, 'utf-8');
+        return JSON.parse(content);
+    }
+
+    updateConfig(newConfig: any): {success: boolean, errors?: string[]}
+    {
+        // Validate against JSON schema
+        try {
+            const schema = this.getSchema();
+            const ajv = new Ajv({allErrors: true});
+            const validate = ajv.compile(schema);
+            const valid = validate(newConfig);
+
+            if(!valid && validate.errors)
+            {
+                const errors = validate.errors.map(e =>
+                    `${e.instancePath || '/'}: ${e.message}`
+                );
+                return {success: false, errors};
+            }
+        } catch(error) {
+            return {success: false, errors: [`Schema validation error: ${String(error)}`]};
+        }
+
+        // Write YAML
+        try {
+            const yamlContent = stringifyYaml(newConfig, {indent: 2});
+            fs.writeFileSync(this.#configFile, yamlContent, 'utf-8');
+            return {success: true};
+        } catch(error) {
+            return {success: false, errors: [`Failed to write config: ${String(error)}`]};
+        }
+    }
+
+    #maskSecrets(config: any)
+    {
+        // Mask send.appReg.secret
+        if(config?.send?.appReg?.secret)
+            config.send.appReg.secret = '********';
+
+        // Mask account secrets
+        if(config?.accounts)
+        {
+            for(const account of config.accounts)
+            {
+                if(account?.appReg?.secret)
+                    account.appReg.secret = '********';
+            }
+        }
+
+        // Mask user passwords
+        if(config?.receive?.users)
+        {
+            for(const user of config.receive.users)
+            {
+                if(user?.password)
+                    user.password = '********';
+            }
+        }
+
+        // Mask webui password
+        if(config?.webui?.password)
+            config.webui.password = '********';
+    }
+}

--- a/src/webui/services/HealthService.ts
+++ b/src/webui/services/HealthService.ts
@@ -1,0 +1,43 @@
+import { MailQueue } from '../../classes/MailQueue';
+import { SMTPServer } from '../../classes/SMTPServer';
+import { Mailer } from '../../classes/Mailer';
+import { Config } from '../../classes/Config';
+
+export class HealthService
+{
+    #queue: MailQueue;
+    #smtpServer: SMTPServer;
+
+    constructor(queue: MailQueue, smtpServer: SMTPServer)
+    {
+        this.#queue = queue;
+        this.#smtpServer = smtpServer;
+    }
+
+    async getHealth()
+    {
+        const accountHealth = [];
+        for(const account of Config.accounts)
+        {
+            const connectivity = await Mailer.testConnection(account);
+            accountHealth.push({
+                name: account.name,
+                tenant: account.appReg.tenant,
+                graphApi: connectivity,
+            });
+        }
+
+        return {
+            smtp: {
+                listening: this.#smtpServer.isListening,
+                port: Config.smtpPort,
+                mode: Config.mode,
+            },
+            accounts: accountHealth,
+            queue: this.#queue.queueStats,
+            paused: this.#queue.isPaused,
+            uptime: process.uptime(),
+            version: VERSION,
+        };
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,10 +17,26 @@ module.exports = (env, argv) => ({
                 test: /\.ts$/,
                 loader: 'ts-loader'
             },
+            // Embed WebUI static files as strings
+            {
+                test: /\.(html|css)$/,
+                include: path.resolve(__dirname, 'src/webui/public'),
+                type: 'asset/source',
+            },
+            {
+                test: /\.js$/,
+                include: path.resolve(__dirname, 'src/webui/public'),
+                type: 'asset/source',
+            },
         ],
     },
     resolve: {
         extensions: ['.ts', '.js'],
+    },
+    // Express and ajv must be loaded at runtime (not bundled)
+    externals: {
+        'express': 'commonjs express',
+        'ajv': 'commonjs ajv',
     },
     plugins: [
         new webpack.DefinePlugin({


### PR DESCRIPTION
## Summary

- **Multi-account relay**: Multiple Azure AD app registrations on one instance, each with its own IP whitelist and allowed senders — modelled after IIS6 SMTP virtual servers. Fully backward compatible with existing single-account `send.appReg` configs.
- **WebUI server**: Express-based HTTP server with Basic Auth, mounted only when `webui.enabled: true` in config. Serves a retro Mac OS 9 / Windows 98 themed SPA.
- **Three-tab dashboard**: System Monitor (SMTP status, queue stats, per-account Graph API health, live log viewer), Network Accounts (CRUD for relay accounts), System Properties (config editor with YAML read/write).
- **Sidecar files**: `.meta.json` sidecar written alongside each `.eml` in the queue, recording `accountName`, `clientIp`, `fromAddress`, `timestamp` for multi-tenant routing through the queue.

## Key file changes

| File | Change |
|------|--------|
| `src/classes/Config.ts` | `IAccount` interface, `accounts` getter (with legacy fallback), `findAccountForSender()`, `isIpAllowedByAnyAccount()`, WebUI getters, updated `validate()` |
| `src/classes/Mailer.ts` | Per-account MSAL client map, `sendEml(file, account)`, `testConnection()` |
| `src/classes/SMTPServer.ts` | Account matching in `onConnect`/`onMailFrom`, sidecar writing, `isListening` getter |
| `src/classes/MailQueue.ts` | Sidecar read/move/cleanup, account-aware send, `queueStats`/`isPaused` getters |
| `src/server.ts` | Conditional WebUI startup after SMTP server |
| `src/webui/` | New: WebServer, routes (health/config/accounts), services (ConfigService/HealthService), public (index.html/app.js/style.css) |
| `webpack.config.js` | `asset/source` rules for HTML/CSS/JS, `express`/`ajv` externals |
| `Dockerfile` | Expose port 3000, install runtime `node_modules` for externals |
| `package.json` | Add `express`, `ajv`, `@types/express` |
| `config.schema.json` | `accounts[]` and `webui` schemas, fourth `oneOf` option |
| `config.example.yml` | Multi-account and WebUI configuration examples |

## Test plan

- [ ] Verify existing single-account `send.appReg` config still works (backward compat)
- [ ] Verify no WebUI starts when `webui` config is absent
- [ ] Add `webui: {enabled: true, ...}` — browse to `http://localhost:3000`, verify Basic Auth prompt
- [ ] Dashboard shows SMTP status, queue counts, account health cards, log viewer
- [ ] Network Accounts tab: Add/Edit/Delete/Test accounts
- [ ] System Properties tab: Edit and save config, restart banner appears
- [ ] Multi-account routing: two accounts with different `allowedIPs`/`allowedFrom` — verify correct account matched in logs and `.meta.json`
- [ ] Docker: `docker build` succeeds, both ports 587 and 3000 accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)